### PR TITLE
attempt to add WBcel235 support

### DIFF
--- a/R/annotate.R
+++ b/R/annotate.R
@@ -18,7 +18,7 @@ gtf2sqlite <- function(assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel
   gtf.gr <- keepStandardChromosomes(gtf.gr)
   seqlevels(gtf.gr) <- paste("chr", seqlevels(gtf.gr), sep="")
   seqlevels(gtf.gr)[which(seqlevels(gtf.gr) == "chrMT")] <- "chrM"
-  txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE, metadata = data.frame(name="Genome", value="GRCh37"))
+  txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE, metadata = data.frame(name="Genome", value=assembly))
   saveDb(txdb, file=db.file)
 
 }

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -11,7 +11,7 @@
 #'
 #' @export
 #' @importFrom AnnotationDbi saveDb
-gtf2sqlite <- function(assembly = c("hg19", "hg38", "mm10", "rn5", "dm6"), db.file) {
+gtf2sqlite <- function(assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel235"), db.file) {
 
   ah <- AnnotationHub()
   gtf.gr <- ah[[getOption("assembly2annhub")[[assembly]]]]
@@ -68,7 +68,7 @@ loadAnnotation <- function(txdb.file) {
 #' @param assembly what genome assembly the input data are coming from
 #'
 #' @export
-annotateCircs <- function(circs.bed, annot.list, assembly = c("hg19", "hg38", "mm10", "rn5", "dm6")) {
+annotateCircs <- function(circs.bed, annot.list, assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel235")) {
 
   DT <- readCircs(file = circs.bed)
   DT <- circLinRatio(sites = DT)

--- a/R/circus.R
+++ b/R/circus.R
@@ -47,6 +47,7 @@ NULL
                            "78"      = "dec2014.archive.ensembl.org",
                            "79"      = "mar2015.archive.ensembl.org",
                            "80"      = "may2015.archive.ensembl.org",
+                           "81"      = "july2015.archive.ensembl.org",
                            "current" = "ensembl.org"
                            ),
 
@@ -57,22 +58,25 @@ NULL
                             "dme" = "dmelanogaster"
                             ),
 
-    assembly2annhub = list("hg19" = "AH10684",
-                           "hg38" = "AH47963",
-                           "mm10" = "AH47973",
-                           "dm6"  = "AH47953",
-                           "rn5"  = "AH28841"
+    assembly2annhub = list("hg19"     = "AH10684",
+                           "hg38"     = "AH47963",
+                           "mm10"     = "AH47973",
+                           "dm6"      = "AH47953",
+                           "rn5"      = "AH28841",
+                           "WBcel235" = "AH47942"
                            ),
-    assembly2release = list("hg19" = "75",
-                            "hg38" = "current",
-                            "mm10" = "current",
-                            "dm6"  = "current",
-                            "rn5"  = "79"
+    assembly2release = list("hg19"     = "75",
+                            "hg38"     = "current",
+                            "mm10"     = "current",
+                            "dm6"      = "current",
+                            "rn5"      = "79",
+                            "WBcel235" = "81"
                             ),
-    assembly2organism = list("hg19" = "hsa",
-                             "hg38" = "hsa",
-                             "mm10" = "mmu",
-                             "dm6"  = "dme"
+    assembly2organism = list("hg19"     = "hsa",
+                             "hg38"     = "hsa",
+                             "mm10"     = "mmu",
+                             "dm6"      = "dme",
+                             "WBcel235" = "cel"
                              )
 
   )

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ install_github("BIMSBbioinfo/ciRcus",build_vignettes=FALSE)
 
 # Using the package
 ### Build TxDb object with genomic features and save locally
-Load genomic features from Ensembl and build a database for later (re)use. Currently supported assemblies are hg19, hg38, mm10, rn5 and dm6. This needs to be done only once per assembly. 
+Load genomic features from Ensembl and build a database for later (re)use. Currently supported assemblies are hg19, hg38, mm10, rn5, dm6 and WBcel235. This needs to be done only once per assembly. 
 ```R
 gtf2sqlite(assembly = "hg19", db.file="data/human_hg19_ens75_txdb.sqlite")
 ```


### PR DESCRIPTION
annotateCircs throws

```
Error in validObject(.Object) : 
  invalid class “GRanges” object: 'x@elementMetadata' is not parallel to 'x'
In addition: Warning messages:
1: In set(DT, j = col, value = as.integer(DT[[col]])) :
  NAs introduced by coercion
2: In set(DT, j = col, value = as.integer(DT[[col]])) :
  NAs introduced by coercion
```
