### PR TITLE
fixed circ2lin file name substitution

### DIFF
--- a/R/readData.R
+++ b/R/readData.R
@@ -42,7 +42,7 @@ readCircs <- function(file, subs="all", qualfilter=TRUE, keepCols=1:6, ...) {
 
   } else if (ncol(DT) >= 21 & names(DT)[1] == '#chrom'){
 
-    DT.lin <- fread(sub("circ", "lin", file), sep="\t", header=T)
+    DT.lin <- fread(sub("circ_splice_sites.bed$", "lin_splice_sites.bed", file), sep="\t", header=T)
     DT.lin$name <- sub("lin", "norm", DT.lin$name)
     DT <- rbind(DT.lin, DT)
 


### PR DESCRIPTION
As discussed last week.
Now this one also hit Panos, so I just 'fixed' it.
Still maybe not the best way to do it but at least much safer than before.

This tested by Panos & seems to work.

Please double-check & merge if acceptable. ;)