### PR TITLE
static code analyis with lintr

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^\.gitignore
 ^\.travis\.yml$
 ^CHANGELOG\.md$
+^\.lintr$

--- a/.lintr
+++ b/.lintr
@@ -3,7 +3,6 @@ linters: with_defaults(
     camel_case_linter = NULL, # 133
     line_length_linter = NULL, # 118
     multiple_dots_linter = NULL, # 88
-    assignment_linter = NULL, # 72
     commented_code_linter = NULL, # 30
     object_usage_linter = NULL, # 22
     spaces_left_parentheses_linter = NULL, # 15

--- a/.lintr
+++ b/.lintr
@@ -7,7 +7,6 @@ linters: with_defaults(
     object_usage_linter = NULL, # 22
     absolute_paths_linter = NULL, # 8
     object_length_linter = NULL, # 4
-    closed_curly_linter = NULL, # 1
     no_tab_linter = NULL, # 1
     trailing_blank_lines_linter = NULL, # 1
     NULL

--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,5 @@
 # see https://github.com/jimhester/lintr#project-configuration
 linters: with_defaults(
-    infix_spaces_linter = NULL, # 221
     camel_case_linter = NULL, # 133
     line_length_linter = NULL, # 118
     single_quotes_linter = NULL, # 101

--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,6 @@
 # see https://github.com/jimhester/lintr#project-configuration
 linters: with_defaults(
     camel_case_linter = NULL, # 133
-    line_length_linter = NULL, # 118
     multiple_dots_linter = NULL, # 88
     commented_code_linter = NULL, # 30
     object_usage_linter = NULL, # 22

--- a/.lintr
+++ b/.lintr
@@ -7,7 +7,6 @@ linters: with_defaults(
     object_usage_linter = NULL, # 22
     absolute_paths_linter = NULL, # 8
     object_length_linter = NULL, # 4
-    open_curly_linter = NULL, # 3
     closed_curly_linter = NULL, # 1
     no_tab_linter = NULL, # 1
     trailing_blank_lines_linter = NULL, # 1

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,20 @@
+# see https://github.com/jimhester/lintr#project-configuration
+linters: with_defaults(
+    infix_spaces_linter = NULL, # 221
+    camel_case_linter = NULL, # 133
+    line_length_linter = NULL, # 118
+    single_quotes_linter = NULL, # 101
+    multiple_dots_linter = NULL, # 88
+    assignment_linter = NULL, # 72
+    commas_linter = NULL, # 30
+    commented_code_linter = NULL, # 30
+    object_usage_linter = NULL, # 22
+    spaces_left_parentheses_linter = NULL, # 15
+    absolute_paths_linter = NULL, # 8
+    object_length_linter = NULL, # 4
+    open_curly_linter = NULL, # 3
+    closed_curly_linter = NULL, # 1
+    no_tab_linter = NULL, # 1
+    trailing_blank_lines_linter = NULL, # 1
+    NULL
+  )

--- a/.lintr
+++ b/.lintr
@@ -2,7 +2,6 @@
 linters: with_defaults(
     camel_case_linter = NULL, # 133
     multiple_dots_linter = NULL, # 88
-    commented_code_linter = NULL, # 30
     object_usage_linter = NULL, # 22
     NULL
   )

--- a/.lintr
+++ b/.lintr
@@ -7,6 +7,5 @@ linters: with_defaults(
     object_usage_linter = NULL, # 22
     absolute_paths_linter = NULL, # 8
     object_length_linter = NULL, # 4
-    trailing_blank_lines_linter = NULL, # 1
     NULL
   )

--- a/.lintr
+++ b/.lintr
@@ -7,7 +7,6 @@ linters: with_defaults(
     object_usage_linter = NULL, # 22
     absolute_paths_linter = NULL, # 8
     object_length_linter = NULL, # 4
-    no_tab_linter = NULL, # 1
     trailing_blank_lines_linter = NULL, # 1
     NULL
   )

--- a/.lintr
+++ b/.lintr
@@ -5,7 +5,6 @@ linters: with_defaults(
     multiple_dots_linter = NULL, # 88
     commented_code_linter = NULL, # 30
     object_usage_linter = NULL, # 22
-    spaces_left_parentheses_linter = NULL, # 15
     absolute_paths_linter = NULL, # 8
     object_length_linter = NULL, # 4
     open_curly_linter = NULL, # 3

--- a/.lintr
+++ b/.lintr
@@ -4,6 +4,8 @@ linters: with_defaults(
     multiple_dots_linter = NULL, # 88
     commented_code_linter = NULL, # 30
     object_usage_linter = NULL, # 22
-    absolute_paths_linter = NULL, # 8
     NULL
+  )
+exclusions: list(
+    "inst/scripts/test_load_data.R"
   )

--- a/.lintr
+++ b/.lintr
@@ -4,7 +4,6 @@ linters: with_defaults(
     line_length_linter = NULL, # 118
     multiple_dots_linter = NULL, # 88
     assignment_linter = NULL, # 72
-    commas_linter = NULL, # 30
     commented_code_linter = NULL, # 30
     object_usage_linter = NULL, # 22
     spaces_left_parentheses_linter = NULL, # 15

--- a/.lintr
+++ b/.lintr
@@ -6,6 +6,5 @@ linters: with_defaults(
     commented_code_linter = NULL, # 30
     object_usage_linter = NULL, # 22
     absolute_paths_linter = NULL, # 8
-    object_length_linter = NULL, # 4
     NULL
   )

--- a/.lintr
+++ b/.lintr
@@ -2,7 +2,6 @@
 linters: with_defaults(
     camel_case_linter = NULL, # 133
     line_length_linter = NULL, # 118
-    single_quotes_linter = NULL, # 101
     multiple_dots_linter = NULL, # 88
     assignment_linter = NULL, # 72
     commas_linter = NULL, # 30

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,5 +35,6 @@ Imports:
     SummarizedExperiment
 Suggests:
     testthat,
-    knitr
+    knitr,
+    lintr
 RoxygenNote: 6.0.1

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -306,16 +306,16 @@ annotateJunctions <- function(se, annot.list) {
 #' @export
 AnnotateRanges <- function(r1, l, ignore.strand = FALSE, type = "precedence", null.fact = "None", collapse.char = ":") {
 
-  if(! class(r1) == "GRanges")
+  if (! class(r1) == "GRanges")
     stop("Ranges to be annotated need to be GRanges")
 
-  if(! all(sapply(l, class) == "GRanges"))
+  if (! all(sapply(l, class) == "GRanges"))
     stop("Annotating ranges need to be GRanges")
 
-  if(!type %in% c("precedence", "all"))
+  if (!type %in% c("precedence", "all"))
     stop("type may only be precedence and all")
 
-  if(class(l) != "GRangesList")
+  if (class(l) != "GRangesList")
     l <- GRangesList(lapply(l, function(x){values(x) <- NULL;x}))
 
   a <- suppressWarnings(data.table(as.matrix(findOverlaps(r1, l, ignore.strand = ignore.strand))))
@@ -323,12 +323,12 @@ AnnotateRanges <- function(r1, l, ignore.strand = FALSE, type = "precedence", nu
   a$precedence <- match(a$id, names(l))
   a <- a[order(a$precedence)]
 
-  if(type == "precedence"){
+  if (type == "precedence"){
     a <- a[!duplicated(a$queryHits)]
 
   }
 
-  if(type == "all"){
+  if (type == "all"){
     a <- a[, list(id = paste(unique(id), collapse = collapse.char)), by = "queryHits"]
   }
 

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -14,10 +14,10 @@ gtf2sqlite <- function(assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel
   ah <- AnnotationHub()
   gtf.gr <- ah[[getOption("assembly2annhub")[[assembly]]]]
   gtf.gr <- keepStandardChromosomes(gtf.gr)
-  seqlevels(gtf.gr) <- paste("chr", seqlevels(gtf.gr), sep="")
+  seqlevels(gtf.gr) <- paste("chr", seqlevels(gtf.gr), sep = "")
   seqlevels(gtf.gr)[which(seqlevels(gtf.gr) == "chrMT")] <- "chrM"
-  txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE, metadata = data.frame(name="Genome", value=assembly))
-  saveDb(txdb, file=db.file)
+  txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE, metadata = data.frame(name = "Genome", value = assembly))
+  saveDb(txdb, file = db.file)
 
 }
 
@@ -74,7 +74,7 @@ setGeneric("annotateCircs",
            function(se,
                     annot.list,
                     assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel235"),
-                    fixCoordIndexing=TRUE,
+                    fixCoordIndexing = TRUE,
                     ...)
              standardGeneric("annotateCircs"))
 
@@ -86,9 +86,9 @@ setMethod("annotateCircs", signature("RangedSummarizedExperiment"),
             if (fixCoordIndexing == TRUE) {
               message('checking out coordinate indexing...')
               coordfix <- testCoordinateIndexing(rowRanges(se), annot.list$gene.feats$cds)
-              tophits <- sapply(coordfix, function(x) which(x/sum(x) > 0.9))
-              if (!is.na(max(coordfix[[1]][2:3]/sum(coordfix[[1]])) > 0.9) &
-                  max(coordfix[[1]][2:3]/sum(coordfix[[1]])) > 0.9) {
+              tophits <- sapply(coordfix, function(x) which(x / sum(x) > 0.9))
+              if (!is.na(max(coordfix[[1]][2:3] / sum(coordfix[[1]])) > 0.9) &
+                  max(coordfix[[1]][2:3] / sum(coordfix[[1]])) > 0.9) {
                 if (tophits[1] == 2) {
                   start(se) <- start(se) + 1
                 } else if (tophits[1] == 3) {
@@ -97,8 +97,8 @@ setMethod("annotateCircs", signature("RangedSummarizedExperiment"),
                 warning("start coordinates modified to match annotation.")
               }
 
-              if (!is.na(max(coordfix[[2]][2:3]/sum(coordfix[[2]])) > 0.9) &
-                  max(coordfix[[2]][2:3]/sum(coordfix[[2]])) > 0.9) {
+              if (!is.na(max(coordfix[[2]][2:3] / sum(coordfix[[2]])) > 0.9) &
+                  max(coordfix[[2]][2:3] / sum(coordfix[[2]])) > 0.9) {
                 if (tophits[2] == 2) {
                   end(se) <- end(se) + 1
                 } else if (tophits[2] == 3) {
@@ -159,22 +159,22 @@ annotateHostGenes <- function(se, genes.gr) {
   circ.ends.gr <- circs.gr
   start(circ.ends.gr) <- end(circ.ends.gr)
 
-  olap.start <- findOverlaps(circ.starts.gr, genes.gr, type="within")
-  olap.end   <- findOverlaps(circ.ends.gr, genes.gr, type="within")
+  olap.start <- findOverlaps(circ.starts.gr, genes.gr, type = "within")
+  olap.end   <- findOverlaps(circ.ends.gr, genes.gr, type = "within")
 
   circs <- data.table(start.hit = names(circs.gr) %in% queryHits(olap.start),
                       end.hit   = names(circs.gr) %in% queryHits(olap.end),
                       id        = circs.gr$id,
                       ord       = 1:length(circs.gr))
 
-  matches.start <- data.table(id=circs.gr$id[queryHits(olap.start)], gene=names(genes.gr)[subjectHits(olap.start)] )
-  matches.end   <- data.table(id=circs.gr$id[queryHits(olap.end)],   gene=names(genes.gr)[subjectHits(olap.end)] )
+  matches.start <- data.table(id = circs.gr$id[queryHits(olap.start)], gene = names(genes.gr)[subjectHits(olap.start)] )
+  matches.end   <- data.table(id = circs.gr$id[queryHits(olap.end)],   gene = names(genes.gr)[subjectHits(olap.end)] )
 
   start.list <- lapply(split(matches.start, matches.start$id), function(x) x$gene)
   end.list   <- lapply(split(matches.end,   matches.end$id),   function(x) x$gene)
 
-  circs <- merge(circs, data.table(id=names(start.list), starts=sapply(start.list, function(x) paste(x, collapse=","))), by="id", all.x=T)
-  circs <- merge(circs, data.table(id=names(end.list), ends=sapply(end.list, function(x) paste(x, collapse=","))), by="id", all.x=T)
+  circs <- merge(circs, data.table(id = names(start.list), starts = sapply(start.list, function(x) paste(x, collapse = ","))), by = "id", all.x = T)
+  circs <- merge(circs, data.table(id = names(end.list), ends = sapply(end.list, function(x) paste(x, collapse = ","))), by = "id", all.x = T)
 
   hs <- hash(start.list)
   he <- hash(end.list)
@@ -186,7 +186,7 @@ annotateHostGenes <- function(se, genes.gr) {
   host.candidates <- integer()
   for (circ in circs$id) {
     tmphits <- append(tmphits, sum(hs[[circ]] %in% he[[circ]]))
-    tmpgenes <- append(tmpgenes, paste(hs[[circ]][hs[[circ]] %in% he[[circ]]], collapse=","))
+    tmpgenes <- append(tmpgenes, paste(hs[[circ]][hs[[circ]] %in% he[[circ]]], collapse = ","))
     host.candidates <- append(host.candidates, length(unique(c(hs[[circ]], he[[circ]]))))
   }
 
@@ -196,7 +196,7 @@ annotateHostGenes <- function(se, genes.gr) {
 
   circs$host[circs$hitcnt == 1] <- circs$hitgenes[circs$hitcnt == 1]
   circs$host[circs$hitcnt > 1]  <- "ambiguous"
-  circs$host[circs$hitcnt == 0 & circs$start.hit == FALSE & circs$end.hit == FALSE] <- "intergenic" # TODO: actually, some of them may have a putative host gene within, I was only testing starts/ends
+  circs$host[circs$hitcnt == 0 & circs$start.hit == FALSE & circs$end.hit == FALSE] <- "intergenic" # TODO: actually, some of them may have a putative host gene within, I was only testing starts / ends
   circs$host[circs$hitcnt == 0 & circs$start.hit == TRUE  & circs$end.hit == TRUE]  <- "no_single_host"
   circs$host[circs$hitcnt == 0 & xor(circs$start.hit, circs$end.hit) & circs$host.candidates > 1] <- "ambiguous"
   circs$host[circs$hitcnt == 0 & circs$start.hit == TRUE  & circs$end.hit == FALSE & circs$host.candidates == 1] <- circs$starts[circs$hitcnt == 0 & circs$start.hit == TRUE   & circs$end.hit == FALSE & circs$host.candidates == 1]
@@ -231,13 +231,13 @@ annotateFlanks <- function(se, annot.list) {
   start(circ.ends.gr) <- end(circ.ends.gr)
 
   # cat('Annotating circRNAs...\n')
-  circ.starts.gr$feat_start     <- AnnotateRanges(r1=circ.starts.gr, l=annot.list,  null.fact="intergenic", type="precedence")
-  circ.ends.gr$feat_end         <- AnnotateRanges(r1=circ.ends.gr,   l=annot.list,  null.fact="intergenic", type="precedence")
+  circ.starts.gr$feat_start     <- AnnotateRanges(r1 = circ.starts.gr, l = annot.list,  null.fact = "intergenic", type = "precedence")
+  circ.ends.gr$feat_end         <- AnnotateRanges(r1 = circ.ends.gr,   l = annot.list,  null.fact = "intergenic", type = "precedence")
 
 
   rowRanges(se)$feature <- ifelse(as.character(strand(rowRanges(se))) == "+",
-                                  paste(circ.starts.gr$feat_start, circ.ends.gr$feat_end,   sep=":"),
-                                  paste(circ.ends.gr$feat_end,     circ.starts.gr$feat_start, sep=":"))
+                                  paste(circ.starts.gr$feat_start, circ.ends.gr$feat_end,   sep = ":"),
+                                  paste(circ.ends.gr$feat_end,     circ.starts.gr$feat_start, sep = ":"))
 
 
   return(se)
@@ -268,8 +268,8 @@ annotateJunctions <- function(se, annot.list) {
   start(circ.ends.gr) <- end(circ.ends.gr)
 
   # cat('Annotating circRNAs...\n')
-  circ.starts.gr$annotated_start_junction <- AnnotateRanges(r1 = circ.starts.gr, l = annot.list, type="precedence")
-  circ.ends.gr$annotated_end_junction     <- AnnotateRanges(r1 = circ.ends.gr,   l = annot.list, type="precedence")
+  circ.starts.gr$annotated_start_junction <- AnnotateRanges(r1 = circ.starts.gr, l = annot.list, type = "precedence")
+  circ.ends.gr$annotated_end_junction     <- AnnotateRanges(r1 = circ.ends.gr,   l = annot.list, type = "precedence")
 
 
   circ.starts.gr$annotated_start_junction <- ifelse(circ.starts.gr$annotated_start_junction == "None", FALSE, TRUE)
@@ -304,7 +304,7 @@ annotateJunctions <- function(se, annot.list) {
 #' @param collapse.char a collapse character for multiple hits in \code{all} mode
 #'
 #' @export
-AnnotateRanges = function(r1, l, ignore.strand=FALSE, type = 'precedence', null.fact = 'None', collapse.char=':') {
+AnnotateRanges = function(r1, l, ignore.strand = FALSE, type = 'precedence', null.fact = 'None', collapse.char = ':') {
 
   if(! class(r1) == 'GRanges')
     stop('Ranges to be annotated need to be GRanges')
@@ -316,9 +316,9 @@ AnnotateRanges = function(r1, l, ignore.strand=FALSE, type = 'precedence', null.
     stop('type may only be precedence and all')
 
   if(class(l) != 'GRangesList')
-    l = GRangesList(lapply(l, function(x){values(x)=NULL;x}))
+    l = GRangesList(lapply(l, function(x){values(x) = NULL;x}))
 
-  a = suppressWarnings(data.table(as.matrix(findOverlaps(r1, l, ignore.strand=ignore.strand))))
+  a = suppressWarnings(data.table(as.matrix(findOverlaps(r1, l, ignore.strand = ignore.strand))))
   a$id = names(l)[a$subjectHits]
   a$precedence = match(a$id,names(l))
   a = a[order(a$precedence)]
@@ -328,7 +328,7 @@ AnnotateRanges = function(r1, l, ignore.strand=FALSE, type = 'precedence', null.
   }
 
   if(type == 'all'){
-    a = a[,list(id=paste(unique(id),collapse=collapse.char)),by='queryHits']
+    a = a[,list(id = paste(unique(id),collapse = collapse.char)),by = 'queryHits']
   }
 
   annot = rep(null.fact, length(r1))
@@ -354,7 +354,7 @@ ensg2name <- function(ensg, organism, release = "current") {
   ensembl.host <- getOption("ensembl.release")[[release]]
 
   ensembl = useMart(biomart = "ENSEMBL_MART_ENSEMBL", host = ensembl.host)
-  ensembl = useDataset(dataset = paste(getOption("ensembl.organism")[[organism]], "_gene_ensembl", sep=""), mart = ensembl)
+  ensembl = useDataset(dataset = paste(getOption("ensembl.organism")[[organism]], "_gene_ensembl", sep = ""), mart = ensembl)
 
   xrefs <- getBM(attributes = c("external_gene_id", "ensembl_gene_id"),
                  filter     = "ensembl_gene_id",

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -84,7 +84,7 @@ setMethod("annotateCircs", signature("RangedSummarizedExperiment"),
           function(se, annot.list, assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel235"), fixCoordIndexing = TRUE, ...) {
 
             if (fixCoordIndexing == TRUE) {
-              message('checking out coordinate indexing...')
+              message("checking out coordinate indexing...")
               coordfix <- testCoordinateIndexing(rowRanges(se), annot.list$gene.feats$cds)
               tophits <- sapply(coordfix, function(x) which(x / sum(x) > 0.9))
               if (!is.na(max(coordfix[[1]][2:3] / sum(coordfix[[1]])) > 0.9) &
@@ -113,23 +113,23 @@ setMethod("annotateCircs", signature("RangedSummarizedExperiment"),
 
             # check seqlevel style, match input
             if (!any(seqlevelsStyle(annot.list$genes) %in% seqlevelsStyle(se))) {
-              warning('nonmatching seqlevel styles, will fix automatically')
+              warning("nonmatching seqlevel styles, will fix automatically")
               for (i in 1:length(annot.list)) {
                 seqlevelsStyle(annot.list[[i]]) <- seqlevelsStyle(se)
               }
             }
 
-            message('annotating host genes...')
+            message("annotating host genes...")
             se <- annotateHostGenes(se, annot.list$genes)
-            message('annotating splice junctions...')
+            message("annotating splice junctions...")
             se <- annotateFlanks(se, annot.list$gene.feats)
             se <- annotateJunctions(se, annot.list$junctions)
 
             if (grepl("linear", names(assays(se)))) {
-              message('calculating circular/linear ratios...')
+              message("calculating circular/linear ratios...")
               se <- circLinRatio(se)
             } else {
-              message('no linear splicing info found, skipping circular/linear ratios...')
+              message("no linear splicing info found, skipping circular/linear ratios...")
             }
 
             return(se)
@@ -230,7 +230,7 @@ annotateFlanks <- function(se, annot.list) {
   circ.ends.gr <- circs.gr
   start(circ.ends.gr) <- end(circ.ends.gr)
 
-  # cat('Annotating circRNAs...\n')
+  # cat("Annotating circRNAs...\n")
   circ.starts.gr$feat_start     <- AnnotateRanges(r1 = circ.starts.gr, l = annot.list,  null.fact = "intergenic", type = "precedence")
   circ.ends.gr$feat_end         <- AnnotateRanges(r1 = circ.ends.gr,   l = annot.list,  null.fact = "intergenic", type = "precedence")
 
@@ -267,7 +267,7 @@ annotateJunctions <- function(se, annot.list) {
   circ.ends.gr <- circs.gr
   start(circ.ends.gr) <- end(circ.ends.gr)
 
-  # cat('Annotating circRNAs...\n')
+  # cat("Annotating circRNAs...\n")
   circ.starts.gr$annotated_start_junction <- AnnotateRanges(r1 = circ.starts.gr, l = annot.list, type = "precedence")
   circ.ends.gr$annotated_end_junction     <- AnnotateRanges(r1 = circ.ends.gr,   l = annot.list, type = "precedence")
 
@@ -304,18 +304,18 @@ annotateJunctions <- function(se, annot.list) {
 #' @param collapse.char a collapse character for multiple hits in \code{all} mode
 #'
 #' @export
-AnnotateRanges = function(r1, l, ignore.strand = FALSE, type = 'precedence', null.fact = 'None', collapse.char = ':') {
+AnnotateRanges = function(r1, l, ignore.strand = FALSE, type = "precedence", null.fact = "None", collapse.char = ":") {
 
-  if(! class(r1) == 'GRanges')
-    stop('Ranges to be annotated need to be GRanges')
+  if(! class(r1) == "GRanges")
+    stop("Ranges to be annotated need to be GRanges")
 
-  if(! all(sapply(l, class) == 'GRanges'))
-    stop('Annotating ranges need to be GRanges')
+  if(! all(sapply(l, class) == "GRanges"))
+    stop("Annotating ranges need to be GRanges")
 
-  if(!type %in% c('precedence','all'))
-    stop('type may only be precedence and all')
+  if(!type %in% c("precedence","all"))
+    stop("type may only be precedence and all")
 
-  if(class(l) != 'GRangesList')
+  if(class(l) != "GRangesList")
     l = GRangesList(lapply(l, function(x){values(x) = NULL;x}))
 
   a = suppressWarnings(data.table(as.matrix(findOverlaps(r1, l, ignore.strand = ignore.strand))))
@@ -323,12 +323,12 @@ AnnotateRanges = function(r1, l, ignore.strand = FALSE, type = 'precedence', nul
   a$precedence = match(a$id,names(l))
   a = a[order(a$precedence)]
 
-  if(type == 'precedence'){
+  if(type == "precedence"){
     a = a[!duplicated(a$queryHits)]
   }
 
-  if(type == 'all'){
-    a = a[,list(id = paste(unique(id),collapse = collapse.char)),by = 'queryHits']
+  if(type == "all"){
+    a = a[,list(id = paste(unique(id),collapse = collapse.char)),by = "queryHits"]
   }
 
   annot = rep(null.fact, length(r1))

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -316,8 +316,8 @@ AnnotateRanges <- function(r1, l, ignore.strand = FALSE, type = "precedence", nu
     stop("type may only be precedence and all")
 
   if (class(l) != "GRangesList")
-    l <- GRangesList(lapply(l, function(x){values(x) <- NULL;x}))
-
+    l <- GRangesList(lapply(l, function(x){
+                                 values(x) <- NULL;x}))
   a <- suppressWarnings(data.table(as.matrix(findOverlaps(r1, l, ignore.strand = ignore.strand))))
   a$id <- names(l)[a$subjectHits]
   a$precedence <- match(a$id, names(l))

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -317,7 +317,8 @@ AnnotateRanges <- function(r1, l, ignore.strand = FALSE, type = "precedence", nu
 
   if (class(l) != "GRangesList")
     l <- GRangesList(lapply(l, function(x){
-                                 values(x) <- NULL;x}))
+                                 values(x) <- NULL;x
+                               }))
   a <- suppressWarnings(data.table(as.matrix(findOverlaps(r1, l, ignore.strand = ignore.strand))))
   a$id <- names(l)[a$subjectHits]
   a$precedence <- match(a$id, names(l))

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -78,7 +78,7 @@ setGeneric("annotateCircs",
                     ...)
              standardGeneric("annotateCircs"))
 
-#' @aliases annotateCircs,RangedSummarizedExperiment-method
+#' @aliases annotateCircs, RangedSummarizedExperiment-method
 #' @rdname annotateCircs-methods
 setMethod("annotateCircs", signature("RangedSummarizedExperiment"),
           function(se, annot.list, assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel235"), fixCoordIndexing = TRUE, ...) {
@@ -312,7 +312,7 @@ AnnotateRanges = function(r1, l, ignore.strand = FALSE, type = "precedence", nul
   if(! all(sapply(l, class) == "GRanges"))
     stop("Annotating ranges need to be GRanges")
 
-  if(!type %in% c("precedence","all"))
+  if(!type %in% c("precedence", "all"))
     stop("type may only be precedence and all")
 
   if(class(l) != "GRangesList")
@@ -320,7 +320,7 @@ AnnotateRanges = function(r1, l, ignore.strand = FALSE, type = "precedence", nul
 
   a = suppressWarnings(data.table(as.matrix(findOverlaps(r1, l, ignore.strand = ignore.strand))))
   a$id = names(l)[a$subjectHits]
-  a$precedence = match(a$id,names(l))
+  a$precedence = match(a$id, names(l))
   a = a[order(a$precedence)]
 
   if(type == "precedence"){
@@ -328,7 +328,7 @@ AnnotateRanges = function(r1, l, ignore.strand = FALSE, type = "precedence", nul
   }
 
   if(type == "all"){
-    a = a[,list(id = paste(unique(id),collapse = collapse.char)),by = "queryHits"]
+    a = a[, list(id = paste(unique(id), collapse = collapse.char)), by = "queryHits"]
   }
 
   annot = rep(null.fact, length(r1))

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -9,14 +9,18 @@
 #' @param db.file a file to save SQLite database to
 #'
 #' @export
-gtf2sqlite <- function(assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel235"), db.file) {
+gtf2sqlite <-
+  function(assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel235"),
+           db.file) {
 
   ah <- AnnotationHub()
   gtf.gr <- ah[[getOption("assembly2annhub")[[assembly]]]]
   gtf.gr <- keepStandardChromosomes(gtf.gr)
   seqlevels(gtf.gr) <- paste("chr", seqlevels(gtf.gr), sep = "")
   seqlevels(gtf.gr)[which(seqlevels(gtf.gr) == "chrMT")] <- "chrM"
-  txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE, metadata = data.frame(name = "Genome", value = assembly))
+  txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE,
+                              metadata = data.frame(name = "Genome",
+                                                    value = assembly))
   saveDb(txdb, file = db.file)
 
 }
@@ -25,10 +29,11 @@ gtf2sqlite <- function(assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel
 # ---------------------------------------------------------------------------- #
 #' Load annotation and prepare a list of features for later
 #'
-#' Loads a local .sqlite TxDb annotation file (e.g. created using \code{gtf2sqlite}),
-#' returns a list of features needed for circRNA annotation.
+#' Loads a local .sqlite TxDb annotation file (e.g. created using
+#' \code{gtf2sqlite}), returns a list of features needed for circRNA annotation.
 #'
-#' @param txdb.file path to the TxDb gene annotation file saved as SQLite database
+#' @param txdb.file path to the TxDb gene annotation file saved as SQLite
+#' database
 #'
 #' @export
 loadAnnotation <- function(txdb.file) {
@@ -40,11 +45,12 @@ loadAnnotation <- function(txdb.file) {
   junct.end <- exns
   start(junct.end) <- end(junct.end)
 
-  gene.feats <- GRangesList(cds    = reduce(cds(txdb)),
-                            utr5   = reduce(unlist(fiveUTRsByTranscript(txdb))),
-                            utr3   = reduce(unlist(threeUTRsByTranscript(txdb))),
-                            intron = reduce(unlist(intronsByTranscript(txdb))),
-                            tx     = reduce(exns))
+  gene.feats <-
+    GRangesList(cds    = reduce(cds(txdb)),
+                utr5   = reduce(unlist(fiveUTRsByTranscript(txdb))),
+                utr3   = reduce(unlist(threeUTRsByTranscript(txdb))),
+                intron = reduce(unlist(intronsByTranscript(txdb))),
+                tx     = reduce(exns))
   junctions <- GRangesList(start = junct.start,
                            end   = junct.end)
 
@@ -62,7 +68,8 @@ loadAnnotation <- function(txdb.file) {
 #' genomic features
 #'
 #' @param se a SummarizedExperiment object
-#' @param annot.list list of relevant genomic features generated using \code{loadAnnotation()}
+#' @param annot.list list of relevant genomic features generated using
+#' \code{loadAnnotation()}
 #' @param assembly what genome assembly the input data are coming from
 #' @param fixCoordIndexing check and fix genomic coordinate indexing?
 #' @param ... other arguments
@@ -73,7 +80,8 @@ loadAnnotation <- function(txdb.file) {
 setGeneric("annotateCircs",
            function(se,
                     annot.list,
-                    assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel235"),
+                    assembly = c("hg19", "hg38", "mm10", "rn5", "dm6",
+                                 "WBcel235"),
                     fixCoordIndexing = TRUE,
                     ...)
              standardGeneric("annotateCircs"))
@@ -81,11 +89,15 @@ setGeneric("annotateCircs",
 #' @aliases annotateCircs, RangedSummarizedExperiment-method
 #' @rdname annotateCircs-methods
 setMethod("annotateCircs", signature("RangedSummarizedExperiment"),
-          function(se, annot.list, assembly = c("hg19", "hg38", "mm10", "rn5", "dm6", "WBcel235"), fixCoordIndexing = TRUE, ...) {
+          function(se, annot.list,
+                   assembly = c("hg19", "hg38", "mm10", "rn5", "dm6",
+                                "WBcel235"),
+                   fixCoordIndexing = TRUE, ...) {
 
             if (fixCoordIndexing == TRUE) {
               message("checking out coordinate indexing...")
-              coordfix <- testCoordinateIndexing(rowRanges(se), annot.list$gene.feats$cds)
+              coordfix <- testCoordinateIndexing(rowRanges(se),
+                                                 annot.list$gene.feats$cds)
               tophits <- sapply(coordfix, function(x) which(x / sum(x) > 0.9))
               if (!is.na(max(coordfix[[1]][2:3] / sum(coordfix[[1]])) > 0.9) &
                   max(coordfix[[1]][2:3] / sum(coordfix[[1]])) > 0.9) {
@@ -112,7 +124,8 @@ setMethod("annotateCircs", signature("RangedSummarizedExperiment"),
             }
 
             # check seqlevel style, match input
-            if (!any(seqlevelsStyle(annot.list$genes) %in% seqlevelsStyle(se))) {
+            if (!any(seqlevelsStyle(annot.list$genes) %in%
+                     seqlevelsStyle(se))) {
               warning("nonmatching seqlevel styles, will fix automatically")
               for (i in 1:length(annot.list)) {
                 seqlevelsStyle(annot.list[[i]]) <- seqlevelsStyle(se)
@@ -129,7 +142,8 @@ setMethod("annotateCircs", signature("RangedSummarizedExperiment"),
               message("calculating circular/linear ratios...")
               se <- circLinRatio(se)
             } else {
-              message("no linear splicing info found, skipping circular/linear ratios...")
+              message(paste("no linear splicing info found, skipping",
+                            "circular/linear ratios..."))
             }
 
             return(se)
@@ -150,7 +164,8 @@ annotateHostGenes <- function(se, genes.gr) {
 
   # circs to GR
   circs.gr <- rowRanges(se)
-  circs.gr$id <- paste0(seqnames(circs.gr), ":", start(circs.gr), "-", end(circs.gr))
+  circs.gr$id <- paste0(seqnames(circs.gr), ":", start(circs.gr), "-",
+                        end(circs.gr))
 
 
   # GR with circ starts and ends only (left and right flanks, actually)
@@ -167,14 +182,28 @@ annotateHostGenes <- function(se, genes.gr) {
                       id        = circs.gr$id,
                       ord       = 1:length(circs.gr))
 
-  matches.start <- data.table(id = circs.gr$id[queryHits(olap.start)], gene = names(genes.gr)[subjectHits(olap.start)] )
-  matches.end   <- data.table(id = circs.gr$id[queryHits(olap.end)],   gene = names(genes.gr)[subjectHits(olap.end)] )
+  matches.start <- data.table(id = circs.gr$id[queryHits(olap.start)],
+                              gene = names(genes.gr)[subjectHits(olap.start)])
+  matches.end   <- data.table(id = circs.gr$id[queryHits(olap.end)],
+                              gene = names(genes.gr)[subjectHits(olap.end)])
 
-  start.list <- lapply(split(matches.start, matches.start$id), function(x) x$gene)
-  end.list   <- lapply(split(matches.end,   matches.end$id),   function(x) x$gene)
+  start.list <- lapply(split(matches.start, matches.start$id),
+                       function(x) x$gene)
+  end.list   <- lapply(split(matches.end,   matches.end$id),
+                       function(x) x$gene)
 
-  circs <- merge(circs, data.table(id = names(start.list), starts = sapply(start.list, function(x) paste(x, collapse = ","))), by = "id", all.x = T)
-  circs <- merge(circs, data.table(id = names(end.list), ends = sapply(end.list, function(x) paste(x, collapse = ","))), by = "id", all.x = T)
+  circs <- merge(circs,
+                 data.table(id = names(start.list),
+                            starts = sapply(start.list,
+                                            function(x)
+                                              paste(x, collapse = ","))),
+                 by = "id", all.x = T)
+  circs <- merge(circs,
+                 data.table(id = names(end.list),
+                            ends = sapply(end.list,
+                                          function(x)
+                                            paste(x, collapse = ","))),
+                 by = "id", all.x = T)
 
   hs <- hash(start.list)
   he <- hash(end.list)
@@ -186,8 +215,10 @@ annotateHostGenes <- function(se, genes.gr) {
   host.candidates <- integer()
   for (circ in circs$id) {
     tmphits <- append(tmphits, sum(hs[[circ]] %in% he[[circ]]))
-    tmpgenes <- append(tmpgenes, paste(hs[[circ]][hs[[circ]] %in% he[[circ]]], collapse = ","))
-    host.candidates <- append(host.candidates, length(unique(c(hs[[circ]], he[[circ]]))))
+    tmpgenes <- append(tmpgenes, paste(hs[[circ]][hs[[circ]] %in% he[[circ]]],
+                                       collapse = ","))
+    host.candidates <- append(host.candidates, length(unique(c(hs[[circ]],
+                                                               he[[circ]]))))
   }
 
   circs$hitcnt <- tmphits
@@ -196,11 +227,22 @@ annotateHostGenes <- function(se, genes.gr) {
 
   circs$host[circs$hitcnt == 1] <- circs$hitgenes[circs$hitcnt == 1]
   circs$host[circs$hitcnt > 1]  <- "ambiguous"
-  circs$host[circs$hitcnt == 0 & circs$start.hit == FALSE & circs$end.hit == FALSE] <- "intergenic" # TODO: actually, some of them may have a putative host gene within, I was only testing starts / ends
-  circs$host[circs$hitcnt == 0 & circs$start.hit == TRUE  & circs$end.hit == TRUE]  <- "no_single_host"
-  circs$host[circs$hitcnt == 0 & xor(circs$start.hit, circs$end.hit) & circs$host.candidates > 1] <- "ambiguous"
-  circs$host[circs$hitcnt == 0 & circs$start.hit == TRUE  & circs$end.hit == FALSE & circs$host.candidates == 1] <- circs$starts[circs$hitcnt == 0 & circs$start.hit == TRUE   & circs$end.hit == FALSE & circs$host.candidates == 1]
-  circs$host[circs$hitcnt == 0 & circs$start.hit == FALSE & circs$end.hit == TRUE & circs$host.candidates == 1]  <- circs$ends[circs$hitcnt == 0   & circs$start.hit == FALSE  & circs$end.hit == TRUE  & circs$host.candidates == 1]
+  # TODO: actually, some of them may have a putative host gene within, I was
+  # only testing starts / ends
+  circs$host[circs$hitcnt == 0 & circs$start.hit == FALSE &
+             circs$end.hit == FALSE] <- "intergenic"
+  circs$host[circs$hitcnt == 0 & circs$start.hit == TRUE  &
+             circs$end.hit == TRUE]  <- "no_single_host"
+  circs$host[circs$hitcnt == 0 & xor(circs$start.hit, circs$end.hit) &
+             circs$host.candidates > 1] <- "ambiguous"
+  circs$host[circs$hitcnt == 0 & circs$start.hit == TRUE  &
+             circs$end.hit == FALSE & circs$host.candidates == 1] <-
+    circs$starts[circs$hitcnt == 0 & circs$start.hit == TRUE   &
+                 circs$end.hit == FALSE & circs$host.candidates == 1]
+  circs$host[circs$hitcnt == 0 & circs$start.hit == FALSE &
+             circs$end.hit == TRUE & circs$host.candidates == 1]  <-
+    circs$ends[circs$hitcnt == 0   & circs$start.hit == FALSE  &
+               circs$end.hit == TRUE  & circs$host.candidates == 1]
 
   rowRanges(se)$gene_id <- circs$host[order(circs$ord)]
 
@@ -231,13 +273,21 @@ annotateFlanks <- function(se, annot.list) {
   start(circ.ends.gr) <- end(circ.ends.gr)
 
   # cat("Annotating circRNAs...\n")
-  circ.starts.gr$feat_start     <- AnnotateRanges(r1 = circ.starts.gr, l = annot.list,  null.fact = "intergenic", type = "precedence")
-  circ.ends.gr$feat_end         <- AnnotateRanges(r1 = circ.ends.gr,   l = annot.list,  null.fact = "intergenic", type = "precedence")
+  circ.starts.gr$feat_start <- AnnotateRanges(r1 = circ.starts.gr,
+                                              l = annot.list,
+                                              null.fact = "intergenic",
+                                              type = "precedence")
+  circ.ends.gr$feat_end     <- AnnotateRanges(r1 = circ.ends.gr,
+                                              l = annot.list,
+                                              null.fact = "intergenic",
+                                              type = "precedence")
 
 
   rowRanges(se)$feature <- ifelse(as.character(strand(rowRanges(se))) == "+",
-                                  paste(circ.starts.gr$feat_start, circ.ends.gr$feat_end,   sep = ":"),
-                                  paste(circ.ends.gr$feat_end,     circ.starts.gr$feat_start, sep = ":"))
+                                  paste(circ.starts.gr$feat_start,
+                                        circ.ends.gr$feat_end,     sep = ":"),
+                                  paste(circ.ends.gr$feat_end,
+                                        circ.starts.gr$feat_start, sep = ":"))
 
 
   return(se)
@@ -268,20 +318,36 @@ annotateJunctions <- function(se, annot.list) {
   start(circ.ends.gr) <- end(circ.ends.gr)
 
   # cat("Annotating circRNAs...\n")
-  circ.starts.gr$annotated_start_junction <- AnnotateRanges(r1 = circ.starts.gr, l = annot.list, type = "precedence")
-  circ.ends.gr$annotated_end_junction     <- AnnotateRanges(r1 = circ.ends.gr,   l = annot.list, type = "precedence")
+  circ.starts.gr$annotated_start_junction <- AnnotateRanges(r1 = circ.starts.gr,
+                                                            l = annot.list,
+                                                            type = "precedence")
+  circ.ends.gr$annotated_end_junction     <- AnnotateRanges(r1 = circ.ends.gr,
+                                                            l = annot.list,
+                                                            type = "precedence")
 
 
-  circ.starts.gr$annotated_start_junction <- ifelse(circ.starts.gr$annotated_start_junction == "None", FALSE, TRUE)
-  circ.ends.gr$annotated_end_junction     <- ifelse(circ.ends.gr$annotated_end_junction == "None", FALSE, TRUE)
+  circ.starts.gr$annotated_start_junction <-
+    ifelse(circ.starts.gr$annotated_start_junction == "None", FALSE, TRUE)
+  circ.ends.gr$annotated_end_junction     <-
+    ifelse(circ.ends.gr$annotated_end_junction == "None", FALSE, TRUE)
 
   junct.known <- rep("", length(circs.gr))
-  junct.known[circ.starts.gr$annotated_start_junction == TRUE  & circ.ends.gr$annotated_end_junction == TRUE] <- "both"
-  junct.known[circ.starts.gr$annotated_start_junction == FALSE & circ.ends.gr$annotated_end_junction == FALSE] <- "none"
-  junct.known[circ.starts.gr$annotated_start_junction == TRUE  & circ.ends.gr$annotated_end_junction == FALSE & as.logical(strand(circs.gr) == "+")] <- "5pr"
-  junct.known[circ.starts.gr$annotated_start_junction == TRUE  & circ.ends.gr$annotated_end_junction == FALSE & as.logical(strand(circs.gr) == "-")] <- "3pr"
-  junct.known[circ.starts.gr$annotated_start_junction == FALSE & circ.ends.gr$annotated_end_junction == TRUE  & as.logical(strand(circs.gr) == "+")] <- "3pr"
-  junct.known[circ.starts.gr$annotated_start_junction == FALSE & circ.ends.gr$annotated_end_junction == TRUE  & as.logical(strand(circs.gr) == "-")] <- "5pr"
+  junct.known[circ.starts.gr$annotated_start_junction == TRUE  &
+              circ.ends.gr$annotated_end_junction == TRUE] <- "both"
+  junct.known[circ.starts.gr$annotated_start_junction == FALSE &
+              circ.ends.gr$annotated_end_junction == FALSE] <- "none"
+  junct.known[circ.starts.gr$annotated_start_junction == TRUE  &
+              circ.ends.gr$annotated_end_junction == FALSE &
+              as.logical(strand(circs.gr) == "+")] <- "5pr"
+  junct.known[circ.starts.gr$annotated_start_junction == TRUE  &
+              circ.ends.gr$annotated_end_junction == FALSE &
+              as.logical(strand(circs.gr) == "-")] <- "3pr"
+  junct.known[circ.starts.gr$annotated_start_junction == FALSE &
+              circ.ends.gr$annotated_end_junction == TRUE  &
+              as.logical(strand(circs.gr) == "+")] <- "3pr"
+  junct.known[circ.starts.gr$annotated_start_junction == FALSE &
+              circ.ends.gr$annotated_end_junction == TRUE  &
+              as.logical(strand(circs.gr) == "-")] <- "5pr"
 
   rowRanges(se)$junct.known <- junct.known
 
@@ -304,7 +370,8 @@ annotateJunctions <- function(se, annot.list) {
 #' @param collapse.char a collapse character for multiple hits in \code{all} mode
 #'
 #' @export
-AnnotateRanges <- function(r1, l, ignore.strand = FALSE, type = "precedence", null.fact = "None", collapse.char = ":") {
+AnnotateRanges <- function(r1, l, ignore.strand = FALSE, type = "precedence",
+                           null.fact = "None", collapse.char = ":") {
 
   if (! class(r1) == "GRanges")
     stop("Ranges to be annotated need to be GRanges")
@@ -319,7 +386,9 @@ AnnotateRanges <- function(r1, l, ignore.strand = FALSE, type = "precedence", nu
     l <- GRangesList(lapply(l, function(x){
                                  values(x) <- NULL;x
                                }))
-  a <- suppressWarnings(data.table(as.matrix(findOverlaps(r1, l, ignore.strand = ignore.strand))))
+  a <- suppressWarnings(data.table(as.matrix(findOverlaps(r1, l,
+                                                          ignore.strand =
+                                                            ignore.strand))))
   a$id <- names(l)[a$subjectHits]
   a$precedence <- match(a$id, names(l))
   a <- a[order(a$precedence)]
@@ -330,7 +399,8 @@ AnnotateRanges <- function(r1, l, ignore.strand = FALSE, type = "precedence", nu
   }
 
   if (type == "all"){
-    a <- a[, list(id = paste(unique(id), collapse = collapse.char)), by = "queryHits"]
+    a <- a[, list(id = paste(unique(id), collapse = collapse.char)),
+           by = "queryHits"]
   }
 
   annot <- rep(null.fact, length(r1))
@@ -356,7 +426,10 @@ ensg2name <- function(ensg, organism, release = "current") {
   ensembl.host <- getOption("ensembl.release")[[release]]
 
   ensembl <- useMart(biomart = "ENSEMBL_MART_ENSEMBL", host = ensembl.host)
-  ensembl <- useDataset(dataset = paste(getOption("ensembl.organism")[[organism]], "_gene_ensembl", sep = ""), mart = ensembl)
+  ensembl <-
+    useDataset(dataset = paste(getOption("ensembl.organism")[[organism]],
+                               "_gene_ensembl", sep = ""),
+               mart = ensembl)
 
   xrefs <- getBM(attributes = c("external_gene_id", "ensembl_gene_id"),
                  filter     = "ensembl_gene_id",

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -272,7 +272,6 @@ annotateFlanks <- function(se, annot.list) {
   circ.ends.gr <- circs.gr
   start(circ.ends.gr) <- end(circ.ends.gr)
 
-  # cat("Annotating circRNAs...\n")
   circ.starts.gr$feat_start <- AnnotateRanges(r1 = circ.starts.gr,
                                               l = annot.list,
                                               null.fact = "intergenic",
@@ -317,7 +316,6 @@ annotateJunctions <- function(se, annot.list) {
   circ.ends.gr <- circs.gr
   start(circ.ends.gr) <- end(circ.ends.gr)
 
-  # cat("Annotating circRNAs...\n")
   circ.starts.gr$annotated_start_junction <- AnnotateRanges(r1 = circ.starts.gr,
                                                             l = annot.list,
                                                             type = "precedence")

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -304,7 +304,7 @@ annotateJunctions <- function(se, annot.list) {
 #' @param collapse.char a collapse character for multiple hits in \code{all} mode
 #'
 #' @export
-AnnotateRanges = function(r1, l, ignore.strand = FALSE, type = "precedence", null.fact = "None", collapse.char = ":") {
+AnnotateRanges <- function(r1, l, ignore.strand = FALSE, type = "precedence", null.fact = "None", collapse.char = ":") {
 
   if(! class(r1) == "GRanges")
     stop("Ranges to be annotated need to be GRanges")
@@ -316,23 +316,24 @@ AnnotateRanges = function(r1, l, ignore.strand = FALSE, type = "precedence", nul
     stop("type may only be precedence and all")
 
   if(class(l) != "GRangesList")
-    l = GRangesList(lapply(l, function(x){values(x) = NULL;x}))
+    l <- GRangesList(lapply(l, function(x){values(x) <- NULL;x}))
 
-  a = suppressWarnings(data.table(as.matrix(findOverlaps(r1, l, ignore.strand = ignore.strand))))
-  a$id = names(l)[a$subjectHits]
-  a$precedence = match(a$id, names(l))
-  a = a[order(a$precedence)]
+  a <- suppressWarnings(data.table(as.matrix(findOverlaps(r1, l, ignore.strand = ignore.strand))))
+  a$id <- names(l)[a$subjectHits]
+  a$precedence <- match(a$id, names(l))
+  a <- a[order(a$precedence)]
 
   if(type == "precedence"){
-    a = a[!duplicated(a$queryHits)]
+    a <- a[!duplicated(a$queryHits)]
+
   }
 
   if(type == "all"){
-    a = a[, list(id = paste(unique(id), collapse = collapse.char)), by = "queryHits"]
+    a <- a[, list(id = paste(unique(id), collapse = collapse.char)), by = "queryHits"]
   }
 
-  annot = rep(null.fact, length(r1))
-  annot[a$queryHits] = a$id
+  annot <- rep(null.fact, length(r1))
+  annot[a$queryHits] <- a$id
 
   return(annot)
 }
@@ -353,8 +354,8 @@ ensg2name <- function(ensg, organism, release = "current") {
 
   ensembl.host <- getOption("ensembl.release")[[release]]
 
-  ensembl = useMart(biomart = "ENSEMBL_MART_ENSEMBL", host = ensembl.host)
-  ensembl = useDataset(dataset = paste(getOption("ensembl.organism")[[organism]], "_gene_ensembl", sep = ""), mart = ensembl)
+  ensembl <- useMart(biomart = "ENSEMBL_MART_ENSEMBL", host = ensembl.host)
+  ensembl <- useDataset(dataset = paste(getOption("ensembl.organism")[[organism]], "_gene_ensembl", sep = ""), mart = ensembl)
 
   xrefs <- getBM(attributes = c("external_gene_id", "ensembl_gene_id"),
                  filter     = "ensembl_gene_id",

--- a/R/circbase.R
+++ b/R/circbase.R
@@ -13,7 +13,7 @@
 #' @param start start
 #' @param end end
 #' @param strand strand
-getIDs <- function(circs, organism, assembly, chrom="chrom", start="start", end="end", strand="strand") {
+getIDs <- function(circs, organism, assembly, chrom = "chrom", start = "start", end = "end", strand = "strand") {
 
   con <- dbConnect(drv    = dbDriver("MySQL"),
                    host   = getOption("circbase.host"),
@@ -22,21 +22,21 @@ getIDs <- function(circs, organism, assembly, chrom="chrom", start="start", end=
                    dbname = getOption("circbase.db"))
 
   query <- paste( "SELECT circID, chrom, pos_start, pos_end, strand FROM ",
-                  organism, "_", assembly, "_circles", sep="")
+                  organism, "_", assembly, "_circles", sep = "")
 
   rs <- dbSendQuery(con, query)
-  chunk <- data.table(fetch(rs, n=-1))
-  chunk$id <- paste(chunk$chrom, ":", chunk$pos_start, "-", chunk$pos_end, sep="")
+  chunk <- data.table(fetch(rs, n = -1))
+  chunk$id <- paste(chunk$chrom, ":", chunk$pos_start, "-", chunk$pos_end, sep = "")
 
-  circs$id <- paste(circs[[chrom]], ":", circs[[start]], "-", circs[[end]], sep="")
-  out <- merge(circs, chunk[,.(id, circID)], by="id", all.x=T)
+  circs$id <- paste(circs[[chrom]], ":", circs[[start]], "-", circs[[end]], sep = "")
+  out <- merge(circs, chunk[,.(id, circID)], by = "id", all.x = T)
 
   dbHasCompleted(rs)
   dbClearResult(rs)
   dbListTables(con)
   dbDisconnect(con)
 
-  return(out[, !"id", with=F])
+  return(out[, !"id", with = F])
 }
 
 # ---------------------------------------------------------------------------- #
@@ -72,11 +72,11 @@ getStudiesList <- function(organism = NA, assembly = NA, study = NA, sample = NA
     ORGN <- strsplit(tbl, "_")[[1]][1]
     ASM  <- strsplit(tbl, "_")[[1]][2]
 
-    query <- paste("SELECT DISTINCT expID, sample FROM ", tbl, " order by expID, sample", sep="")
+    query <- paste("SELECT DISTINCT expID, sample FROM ", tbl, " order by expID, sample", sep = "")
     rs <- dbSendQuery(con, query)
-    chunk <- data.table(fetch(rs, n=-1))
+    chunk <- data.table(fetch(rs, n = -1))
     setnames(chunk, c("stdy", "smpl"))
-    out <- rbind(out, cbind(orgn=ORGN, asm=ASM, chunk))
+    out <- rbind(out, cbind(orgn = ORGN, asm = ASM, chunk))
 
   }
 
@@ -102,7 +102,7 @@ getStudiesList <- function(organism = NA, assembly = NA, study = NA, sample = NA
   setnames(out, c("organism", "assembly", "study", "sample"))
 
   if (nrow(out) == 0) {
-    stop(paste("no circBase data for organism ", organism, ", assembly ", assembly, ", study ", study, ", and sample ", sample, ".", sep=""))
+    stop(paste("no circBase data for organism ", organism, ", assembly ", assembly, ", study ", study, ", and sample ", sample, ".", sep = ""))
   }
 
   return(out)

--- a/R/circbase.R
+++ b/R/circbase.R
@@ -13,7 +13,8 @@
 #' @param start start
 #' @param end end
 #' @param strand strand
-getIDs <- function(circs, organism, assembly, chrom = "chrom", start = "start", end = "end", strand = "strand") {
+getIDs <- function(circs, organism, assembly, chrom = "chrom", start = "start",
+                   end = "end", strand = "strand") {
 
   con <- dbConnect(drv    = dbDriver("MySQL"),
                    host   = getOption("circbase.host"),
@@ -26,9 +27,11 @@ getIDs <- function(circs, organism, assembly, chrom = "chrom", start = "start", 
 
   rs <- dbSendQuery(con, query)
   chunk <- data.table(fetch(rs, n = -1))
-  chunk$id <- paste(chunk$chrom, ":", chunk$pos_start, "-", chunk$pos_end, sep = "")
+  chunk$id <- paste(chunk$chrom, ":", chunk$pos_start, "-", chunk$pos_end,
+                    sep = "")
 
-  circs$id <- paste(circs[[chrom]], ":", circs[[start]], "-", circs[[end]], sep = "")
+  circs$id <- paste(circs[[chrom]], ":", circs[[start]], "-", circs[[end]],
+                    sep = "")
   out <- merge(circs, chunk[, .(id, circID)], by = "id", all.x = T)
 
   dbHasCompleted(rs)
@@ -53,7 +56,8 @@ getIDs <- function(circs, organism, assembly, chrom = "chrom", start = "start", 
 #' @param sample sample
 #'
 #' @export
-getStudiesList <- function(organism = NA, assembly = NA, study = NA, sample = NA) {
+getStudiesList <- function(organism = NA, assembly = NA, study = NA,
+                           sample = NA) {
 
   con <- dbConnect(drv    = dbDriver("MySQL"),
                    host   = getOption("circbase.host"),
@@ -67,12 +71,14 @@ getStudiesList <- function(organism = NA, assembly = NA, study = NA, sample = NA
   tbls <- tbls[grep("stats", tbls)]
 
   # get all the orgn\assm\study\sample 4-mers
-  out <- data.table(orgn = factor(), asm = factor(), stdy = factor(), smpl = factor())
+  out <- data.table(orgn = factor(), asm = factor(), stdy = factor(),
+                    smpl = factor())
   for (tbl in tbls) {
     ORGN <- strsplit(tbl, "_")[[1]][1]
     ASM  <- strsplit(tbl, "_")[[1]][2]
 
-    query <- paste("SELECT DISTINCT expID, sample FROM ", tbl, " order by expID, sample", sep = "")
+    query <- paste("SELECT DISTINCT expID, sample FROM ", tbl,
+                   " order by expID, sample", sep = "")
     rs <- dbSendQuery(con, query)
     chunk <- data.table(fetch(rs, n = -1))
     setnames(chunk, c("stdy", "smpl"))
@@ -102,7 +108,9 @@ getStudiesList <- function(organism = NA, assembly = NA, study = NA, sample = NA
   setnames(out, c("organism", "assembly", "study", "sample"))
 
   if (nrow(out) == 0) {
-    stop(paste("no circBase data for organism ", organism, ", assembly ", assembly, ", study ", study, ", and sample ", sample, ".", sep = ""))
+    stop(paste("no circBase data for organism ", organism, ", assembly ",
+               assembly, ", study ", study, ", and sample ", sample, ".",
+               sep = ""))
   }
 
   return(out)

--- a/R/circbase.R
+++ b/R/circbase.R
@@ -29,7 +29,7 @@ getIDs <- function(circs, organism, assembly, chrom = "chrom", start = "start", 
   chunk$id <- paste(chunk$chrom, ":", chunk$pos_start, "-", chunk$pos_end, sep = "")
 
   circs$id <- paste(circs[[chrom]], ":", circs[[start]], "-", circs[[end]], sep = "")
-  out <- merge(circs, chunk[,.(id, circID)], by = "id", all.x = T)
+  out <- merge(circs, chunk[, .(id, circID)], by = "id", all.x = T)
 
   dbHasCompleted(rs)
   dbClearResult(rs)

--- a/R/circus.R
+++ b/R/circus.R
@@ -90,7 +90,7 @@ NULL
 
   )
   toset <- !(names(op.circus) %in% names(op))
-  if(any(toset)) options(op.circus[toset])
+  if (any(toset)) options(op.circus[toset])
 
   invisible()
 }

--- a/R/filterData.R
+++ b/R/filterData.R
@@ -19,7 +19,7 @@ qualFilter <- function(sites, n_uniq_thr = 2) {
 
   # pipeline-specific filters
   if (ncol(sites) == 19) {
-    qual.ind <- rowSums(sites[, grepl("best_qual",colnames(sites)), with = FALSE] >= 35) > 0
+    qual.ind <- rowSums(sites[, grepl("best_qual", colnames(sites)), with = FALSE] >= 35) > 0
     sites <- sites[qual.ind]
   } else if (ncol(sites) == 21) {
     sites <- sites[!grepl("HUGE|SHORT", category)]

--- a/R/filterData.R
+++ b/R/filterData.R
@@ -19,7 +19,8 @@ qualFilter <- function(sites, n_uniq_thr = 2) {
 
   # pipeline-specific filters
   if (ncol(sites) == 19) {
-    qual.ind <- rowSums(sites[, grepl("best_qual", colnames(sites)), with = FALSE] >= 35) > 0
+    qual.ind <- rowSums(sites[, grepl("best_qual", colnames(sites)),
+                              with = FALSE] >= 35) > 0
     sites <- sites[qual.ind]
   } else if (ncol(sites) == 21) {
     sites <- sites[!grepl("HUGE|SHORT", category)]

--- a/R/filterData.R
+++ b/R/filterData.R
@@ -8,7 +8,7 @@
 #' @param sites splice site candidates, as read from find_circ.py output by readCircs
 #' @param n_uniq_thr minimal number of unique reads required for calling a splice site
 #'
-qualFilter <- function(sites, n_uniq_thr=2) {
+qualFilter <- function(sites, n_uniq_thr = 2) {
 
   sites <- sites[!(grepl("circ", name) & (end - start > 100000))]
   sites <- sites[breakpoints <= 1]
@@ -19,7 +19,7 @@ qualFilter <- function(sites, n_uniq_thr=2) {
 
   # pipeline-specific filters
   if (ncol(sites) == 19) {
-    qual.ind <- rowSums(sites[, grepl('best_qual',colnames(sites)), with=FALSE] >= 35) > 0
+    qual.ind <- rowSums(sites[, grepl('best_qual',colnames(sites)), with = FALSE] >= 35) > 0
     sites <- sites[qual.ind]
   } else if (ncol(sites) == 21) {
     sites <- sites[!grepl("HUGE|SHORT", category)]

--- a/R/filterData.R
+++ b/R/filterData.R
@@ -19,7 +19,7 @@ qualFilter <- function(sites, n_uniq_thr = 2) {
 
   # pipeline-specific filters
   if (ncol(sites) == 19) {
-    qual.ind <- rowSums(sites[, grepl('best_qual',colnames(sites)), with = FALSE] >= 35) > 0
+    qual.ind <- rowSums(sites[, grepl("best_qual",colnames(sites)), with = FALSE] >= 35) > 0
     sites <- sites[qual.ind]
   } else if (ncol(sites) == 21) {
     sites <- sites[!grepl("HUGE|SHORT", category)]

--- a/R/quantification.R
+++ b/R/quantification.R
@@ -21,7 +21,7 @@ setGeneric("circLinRatio",
 #' @rdname circLinRatio-methods
 setMethod("circLinRatio",
           signature("RangedSummarizedExperiment"),
-          definition=function(se, ...) {
+          definition = function(se, ...) {
 
             assays(se)$ratio <- round(assay(se, 1) / pmax(assay(se, 2), assay(se, 3)), 2)
 

--- a/R/quantification.R
+++ b/R/quantification.R
@@ -23,7 +23,8 @@ setMethod("circLinRatio",
           signature("RangedSummarizedExperiment"),
           definition = function(se, ...) {
 
-            assays(se)$ratio <- round(assay(se, 1) / pmax(assay(se, 2), assay(se, 3)), 2)
+            assays(se)$ratio <- round(assay(se, 1) / pmax(assay(se, 2),
+                                                          assay(se, 3)), 2)
 
             return(se)
           })

--- a/R/readData.R
+++ b/R/readData.R
@@ -22,10 +22,10 @@
 #' @return A data table.
 #'
 #' @export
-readCircs <- function(file, subs="all", qualfilter=TRUE, keepCols=1:6, ...) {
+readCircs <- function(file, subs = "all", qualfilter = TRUE, keepCols = 1:6, ...) {
 
   suppressWarnings(
-    DT <- fread(file, sep="\t", header=T) # maybe add colClasses later
+    DT <- fread(file, sep = "\t", header = T) # maybe add colClasses later
   )
 
   # try to figure out what tool the data are coming from
@@ -39,12 +39,12 @@ readCircs <- function(file, subs="all", qualfilter=TRUE, keepCols=1:6, ...) {
     #    character after fread()
     char.class = c('chrom', 'name', 'strand', 'tissues', 'signal', 'strandmatch', 'category')
     for (col in setdiff(colnames(DT), char.class)){
-      set(DT, j=col, value=as.integer(DT[[col]]))
+      set(DT, j = col, value = as.integer(DT[[col]]))
     }
 
   } else if (ncol(DT) >= 21 & names(DT)[1] == '#chrom'){
     # read find_circ2
-    DT.lin <- fread(sub("circ_splice_sites.bed$", "lin_splice_sites.bed", file), sep="\t", header=T)
+    DT.lin <- fread(sub("circ_splice_sites.bed$", "lin_splice_sites.bed", file), sep = "\t", header = T)
     DT.lin$name <- sub("lin", "norm", DT.lin$name)
     DT <- rbind(DT.lin, DT)
 
@@ -67,7 +67,7 @@ readCircs <- function(file, subs="all", qualfilter=TRUE, keepCols=1:6, ...) {
     DT <- qualFilter(DT)
   }
 
-  DT <- DT[, keepCols, with=F]
+  DT <- DT[, keepCols, with = F]
 
   return(DT)
 }
@@ -101,12 +101,12 @@ readCircs <- function(file, subs="all", qualfilter=TRUE, keepCols=1:6, ...) {
 #'
 #' @export
 setGeneric("summarizeCircs",
-           function(colData=NULL,
-                    keep.linear=TRUE,
+           function(colData = NULL,
+                    keep.linear = TRUE,
                     wobble = 5,
                     subs = 'all',
-                    qualfilter=TRUE,
-                    keepCols=1:6,
+                    qualfilter = TRUE,
+                    keepCols = 1:6,
                     ...)
              standardGeneric("summarizeCircs"))
 
@@ -134,7 +134,7 @@ setMethod("summarizeCircs", signature("data.frame"),
             names(circs) <- colData$sample
 
             dcircs = rbindlist(circs)
-            dcircs$set = factor(rep(names(circs), sapply(circs, nrow)), levels=names(circs))
+            dcircs$set = factor(rep(names(circs), sapply(circs, nrow)), levels = names(circs))
 
             # process circular and linear if input is find_circ
             if (!("SM_MS_SMS" %in% names(circs[[1]]))) { #TODO: find a better way to recognize CIRI2
@@ -148,26 +148,26 @@ setMethod("summarizeCircs", signature("data.frame"),
 
               dcircs = split(dcircs, dcircs$type)
 
-              circ.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs[['circ']]), keep.extra.columns=TRUE)
+              circ.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs[['circ']]), keep.extra.columns = TRUE)
             } else {
               # CIRI2
-              circ.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs), keep.extra.columns=TRUE)
+              circ.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs), keep.extra.columns = TRUE)
             }
 
             # prepare the wobble
             # -------------------------------------- #
-            circ.gr.s = resize(resize(circ.gr, fix='start', width=1), fix='center', width=wobble)
-            circ.gr.e = resize(resize(circ.gr, fix='end',   width=1), fix='center', width=wobble)
+            circ.gr.s = resize(resize(circ.gr, fix = 'start', width = 1), fix = 'center', width = wobble)
+            circ.gr.e = resize(resize(circ.gr, fix = 'end',   width = 1), fix = 'center', width = wobble)
 
-            circ.fos = data.table(as.matrix(findOverlaps(circ.gr.s, reduce(circ.gr.s, ignore.strand=FALSE))))
-            circ.foe = data.table(as.matrix(findOverlaps(circ.gr.e, reduce(circ.gr.e, ignore.strand=FALSE))))
+            circ.fos = data.table(as.matrix(findOverlaps(circ.gr.s, reduce(circ.gr.s, ignore.strand = FALSE))))
+            circ.foe = data.table(as.matrix(findOverlaps(circ.gr.e, reduce(circ.gr.e, ignore.strand = FALSE))))
 
-            merge.fos = merge(circ.fos, circ.foe, by='queryHits', all=TRUE)
+            merge.fos = merge(circ.fos, circ.foe, by = 'queryHits', all = TRUE)
             merge.fos$fac = with(merge.fos, as.numeric(factor(paste(subjectHits.x, subjectHits.y))))
 
-            #circ.gr.reduced = sort(unlist(range(split(circ.gr, merge.fos$fac), ignore.strand=FALSE)))
+            #circ.gr.reduced = sort(unlist(range(split(circ.gr, merge.fos$fac), ignore.strand = FALSE)))
             # TODO: wobble logic is naive, should be improved to select the best expressed circRNA as a referent one
-            circ.gr.reduced = unlist(range(split(circ.gr, merge.fos$fac), ignore.strand=FALSE))
+            circ.gr.reduced = unlist(range(split(circ.gr, merge.fos$fac), ignore.strand = FALSE))
 
             # prepare the assays object
             # TODO: this screams refactoring
@@ -180,17 +180,17 @@ setMethod("summarizeCircs", signature("data.frame"),
               n_reads.dt <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_reads")
               n_uniq.dt  <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_uniq")
 
-              assays$circ      = as.matrix(n_reads.dt[, -1, with=FALSE])
-              assays$circ.uniq = as.matrix( n_uniq.dt[, -1, with=FALSE])
+              assays$circ      = as.matrix(n_reads.dt[, -1, with = FALSE])
+              assays$circ.uniq = as.matrix( n_uniq.dt[, -1, with = FALSE])
 
             } else {
 
               n_reads.dt <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_reads")
-              assays$circ      = as.matrix(n_reads.dt[, -1, with=FALSE])
+              assays$circ      = as.matrix(n_reads.dt[, -1, with = FALSE])
 
             }
 
-            if(keep.linear==TRUE){
+            if(keep.linear == TRUE){
               message('Processing linear transcripts')
               linear = ProcessLinear(dcircs, circ.gr.reduced, wobble)
               assays = c(assays, linear)
@@ -202,9 +202,9 @@ setMethod("summarizeCircs", signature("data.frame"),
                 colData = DataFrame(colData)
 
 
-            sex = SummarizedExperiment(assays=assays,
-                                       rowRanges=circ.gr.reduced,
-                                       colData=colData)
+            sex = SummarizedExperiment(assays = assays,
+                                       rowRanges = circ.gr.reduced,
+                                       colData = colData)
             return(sex)
 
 
@@ -218,13 +218,13 @@ setMethod("summarizeCircs", signature("character"),
             message('Constructing colData...')
             colData = data.frame(sample   = sub('.candidates.bed', '', basename(colData)),
                                  filename = colData,
-                                 stringsAsFactors=FALSE)
+                                 stringsAsFactors = FALSE)
 
-            summarizeCircs(colData=colData,
-                           keep.linear=keep.linear,
-                           wobble=wobble,
-                           subs=subs,
-                           qualfilter=qualfilter,
+            summarizeCircs(colData = colData,
+                           keep.linear = keep.linear,
+                           wobble = wobble,
+                           subs = subs,
+                           qualfilter = qualfilter,
                            keepCols = keepCols)
 })
 
@@ -250,11 +250,11 @@ MungeColumn <- function(merge.fos, circ.gr, circ.gr.reduced, column.name) {
   circ.ex = merge.fos[,.(queryHits, fac)]
   circ.ex$nreads = values(circ.gr)[[column.name]][circ.ex$queryHits]
   circ.ex$set = circ.gr$set[circ.ex$queryHits]
-  circ.ex.matrix = dcast.data.table(formula=fac~set,
-                                    fun.aggregate=sum,
-                                    fill=0,
-                                    value.var='nreads',
-                                    data=circ.ex)
+  circ.ex.matrix = dcast.data.table(formula = fac~set,
+                                    fun.aggregate = sum,
+                                    fill = 0,
+                                    value.var = 'nreads',
+                                    data = circ.ex)
   circ.ex.matrix = circ.ex.matrix[match(names(circ.gr.reduced), circ.ex.matrix$fac)]
 
   return(circ.ex.matrix)
@@ -273,32 +273,32 @@ MungeColumn <- function(merge.fos, circ.gr, circ.gr.reduced, column.name) {
 ProcessLinear = function(dcircs, circ.gr.reduced, wobble){
 
     lin.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs[['linear']]),
-                                       keep.extra.columns=TRUE)
-    circ.gr.s = resize(resize(circ.gr.reduced, fix='start', width=1),
-                       fix='center', width=wobble)
-    circ.gr.e = resize(resize(circ.gr.reduced, fix='end',   width=1),
-                       fix='center', width=wobble)
+                                       keep.extra.columns = TRUE)
+    circ.gr.s = resize(resize(circ.gr.reduced, fix = 'start', width = 1),
+                       fix = 'center', width = wobble)
+    circ.gr.e = resize(resize(circ.gr.reduced, fix = 'end',   width = 1),
+                       fix = 'center', width = wobble)
 
-    cfos = data.table(as.matrix(findOverlaps(resize(lin.gr, fix='start', width=1),
-                                             circ.gr.e, ignore.strand=FALSE)))
-    cfoe = data.table(as.matrix(findOverlaps(resize(lin.gr, fix='end',   width=1),
-                                             circ.gr.s, ignore.strand=FALSE)))
+    cfos = data.table(as.matrix(findOverlaps(resize(lin.gr, fix = 'start', width = 1),
+                                             circ.gr.e, ignore.strand = FALSE)))
+    cfoe = data.table(as.matrix(findOverlaps(resize(lin.gr, fix = 'end',   width = 1),
+                                             circ.gr.s, ignore.strand = FALSE)))
 
     cfos$nreads = lin.gr$n_reads[cfos$queryHits]
     cfos$set = lin.gr$set[cfos$queryHits]
-    cfos$queryHits = factor(cfos$subjectHits, levels=1:length(circ.gr.reduced))
-    cfos.cast = dcast.data.table(formula=queryHits~set, fun.aggregate=sum,fill=0,
-                                 value.var='nreads', data=cfos, drop=FALSE)
+    cfos$queryHits = factor(cfos$subjectHits, levels = 1:length(circ.gr.reduced))
+    cfos.cast = dcast.data.table(formula = queryHits~set, fun.aggregate = sum,fill = 0,
+                                 value.var = 'nreads', data = cfos, drop = FALSE)
     cfos.cast = cfos.cast[match(names(circ.gr.reduced),cfos.cast$queryHits)]
 
     cfoe$nreads = lin.gr$n_reads[cfoe$queryHits]
     cfoe$set = lin.gr$set[cfoe$queryHits]
-    cfoe$queryHits = factor(cfoe$subjectHits, levels=1:length(circ.gr.reduced))
-    cfoe.cast = dcast.data.table(formula=queryHits~set, fun.aggregate=sum,fill=0,
-                                 value.var='nreads', data=cfoe, drop=FALSE)
+    cfoe$queryHits = factor(cfoe$subjectHits, levels = 1:length(circ.gr.reduced))
+    cfoe.cast = dcast.data.table(formula = queryHits~set, fun.aggregate = sum,fill = 0,
+                                 value.var = 'nreads', data = cfoe, drop = FALSE)
     cfoe.cast = cfoe.cast[match(names(circ.gr.reduced),cfoe.cast$queryHits)]
 
-    return(list(linear.start = as.matrix(cfos.cast[,-1,with=FALSE]),
-                linear.end   = as.matrix(cfoe.cast[,-1,with=FALSE])))
+    return(list(linear.start = as.matrix(cfos.cast[,-1,with = FALSE]),
+                linear.end   = as.matrix(cfoe.cast[,-1,with = FALSE])))
 }
 

--- a/R/readData.R
+++ b/R/readData.R
@@ -37,7 +37,7 @@ readCircs <- function(file, subs = "all", qualfilter = TRUE, keepCols = 1:6, ...
     # ***due to find_circ.py logic of putting a header line
     #    in the middle of the output file, all columns are
     #    character after fread()
-    char.class = c("chrom", "name", "strand", "tissues", "signal", "strandmatch", "category")
+    char.class <- c("chrom", "name", "strand", "tissues", "signal", "strandmatch", "category")
     for (col in setdiff(colnames(DT), char.class)){
       set(DT, j = col, value = as.integer(DT[[col]]))
     }
@@ -118,23 +118,23 @@ setMethod("summarizeCircs", signature("data.frame"),
 
             # munge input
             # -------------------------------------- #
-            coldata.cnams = c("sample", "filename")
+            coldata.cnams <- c("sample", "filename")
             if(!all(coldata.cnams %in% colnames(colData)))
                stop(paste(setdiff(coldata.cnams, colnames(colData),
                             "is missing from colData")))
 
-            circ.files = as.character(colData$filename)
+            circ.files <- as.character(colData$filename)
 
             if(!all(file.exists(circ.files)))
               stop("Supplied circ files do not exist")
 
             # load circs
             # -------------------------------------- #
-            circs = lapply(circ.files, readCircs, subs, qualfilter, keepCols)
+            circs <- lapply(circ.files, readCircs, subs, qualfilter, keepCols)
             names(circs) <- colData$sample
 
-            dcircs = rbindlist(circs)
-            dcircs$set = factor(rep(names(circs), sapply(circs, nrow)), levels = names(circs))
+            dcircs <- rbindlist(circs)
+            dcircs$set <- factor(rep(names(circs), sapply(circs, nrow)), levels = names(circs))
 
             # process circular and linear if input is find_circ
             if (!("SM_MS_SMS" %in% names(circs[[1]]))) { #TODO: find a better way to recognize CIRI2
@@ -144,67 +144,67 @@ setMethod("summarizeCircs", signature("data.frame"),
                 dcircs$name <- sub("_circ_norm_", "_norm_", dcircs$name)
                 dcircs$name <- sub("_circ_circ_", "_circ_", dcircs$name)
               }
-              dcircs$type = ifelse(grepl("circ", dcircs$name), "circ", "linear")
+              dcircs$type <- ifelse(grepl("circ", dcircs$name), "circ", "linear")
 
-              dcircs = split(dcircs, dcircs$type)
+              dcircs <- split(dcircs, dcircs$type)
 
-              circ.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs[["circ"]]), keep.extra.columns = TRUE)
+              circ.gr <-  makeGRangesFromDataFrame(as.data.frame(dcircs[["circ"]]), keep.extra.columns = TRUE)
             } else {
               # CIRI2
-              circ.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs), keep.extra.columns = TRUE)
+              circ.gr <-  makeGRangesFromDataFrame(as.data.frame(dcircs), keep.extra.columns = TRUE)
             }
 
             # prepare the wobble
             # -------------------------------------- #
-            circ.gr.s = resize(resize(circ.gr, fix = "start", width = 1), fix = "center", width = wobble)
-            circ.gr.e = resize(resize(circ.gr, fix = "end",   width = 1), fix = "center", width = wobble)
+            circ.gr.s <- resize(resize(circ.gr, fix = "start", width = 1), fix = "center", width = wobble)
+            circ.gr.e <- resize(resize(circ.gr, fix = "end",   width = 1), fix = "center", width = wobble)
 
-            circ.fos = data.table(as.matrix(findOverlaps(circ.gr.s, reduce(circ.gr.s, ignore.strand = FALSE))))
-            circ.foe = data.table(as.matrix(findOverlaps(circ.gr.e, reduce(circ.gr.e, ignore.strand = FALSE))))
+            circ.fos <- data.table(as.matrix(findOverlaps(circ.gr.s, reduce(circ.gr.s, ignore.strand = FALSE))))
+            circ.foe <- data.table(as.matrix(findOverlaps(circ.gr.e, reduce(circ.gr.e, ignore.strand = FALSE))))
 
-            merge.fos = merge(circ.fos, circ.foe, by = "queryHits", all = TRUE)
-            merge.fos$fac = with(merge.fos, as.numeric(factor(paste(subjectHits.x, subjectHits.y))))
+            merge.fos <- merge(circ.fos, circ.foe, by = "queryHits", all = TRUE)
+            merge.fos$fac <- with(merge.fos, as.numeric(factor(paste(subjectHits.x, subjectHits.y))))
 
-            #circ.gr.reduced = sort(unlist(range(split(circ.gr, merge.fos$fac), ignore.strand = FALSE)))
+            #circ.gr.reduced <- sort(unlist(range(split(circ.gr, merge.fos$fac), ignore.strand = FALSE)))
             # TODO: wobble logic is naive, should be improved to select the best expressed circRNA as a referent one
-            circ.gr.reduced = unlist(range(split(circ.gr, merge.fos$fac), ignore.strand = FALSE))
+            circ.gr.reduced <- unlist(range(split(circ.gr, merge.fos$fac), ignore.strand = FALSE))
 
             # prepare the assays object
             # TODO: this screams refactoring
             # -------------------------------------- #
             message("Fetching circular expression")
 
-            assays = list()
+            assays <- list()
             if (!("SM_MS_SMS" %in% names(circs[[1]]))) { #TODO: find a better way to recognize CIRI2
 
               n_reads.dt <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_reads")
               n_uniq.dt  <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_uniq")
 
-              assays$circ      = as.matrix(n_reads.dt[, -1, with = FALSE])
-              assays$circ.uniq = as.matrix( n_uniq.dt[, -1, with = FALSE])
+              assays$circ      <- as.matrix(n_reads.dt[, -1, with = FALSE])
+              assays$circ.uniq <- as.matrix( n_uniq.dt[, -1, with = FALSE])
 
             } else {
 
               n_reads.dt <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_reads")
-              assays$circ      = as.matrix(n_reads.dt[, -1, with = FALSE])
+              assays$circ      <- as.matrix(n_reads.dt[, -1, with = FALSE])
 
             }
 
             if(keep.linear == TRUE){
               message("Processing linear transcripts")
-              linear = ProcessLinear(dcircs, circ.gr.reduced, wobble)
-              assays = c(assays, linear)
+              linear <- ProcessLinear(dcircs, circ.gr.reduced, wobble)
+              assays <- c(assays, linear)
             }
 
 
 
             if(class(colData) == "data.frame")
-                colData = DataFrame(colData)
+                colData <- DataFrame(colData)
 
 
-            sex = SummarizedExperiment(assays = assays,
-                                       rowRanges = circ.gr.reduced,
-                                       colData = colData)
+            sex <- SummarizedExperiment(assays = assays,
+                                        rowRanges = circ.gr.reduced,
+                                        colData = colData)
             return(sex)
 
 
@@ -216,9 +216,9 @@ setMethod("summarizeCircs", signature("character"),
           function(colData, keep.linear, wobble, subs, qualfilter, keepCols){
 
             message("Constructing colData...")
-            colData = data.frame(sample   = sub(".candidates.bed", "", basename(colData)),
-                                 filename = colData,
-                                 stringsAsFactors = FALSE)
+            colData <- data.frame(sample   = sub(".candidates.bed", "", basename(colData)),
+                                  filename = colData,
+                                  stringsAsFactors = FALSE)
 
             summarizeCircs(colData = colData,
                            keep.linear = keep.linear,
@@ -247,15 +247,15 @@ MungeColumn <- function(merge.fos, circ.gr, circ.gr.reduced, column.name) {
     stop("unknown column name: ", column.name)
   }
 
-  circ.ex = merge.fos[, .(queryHits, fac)]
-  circ.ex$nreads = values(circ.gr)[[column.name]][circ.ex$queryHits]
-  circ.ex$set = circ.gr$set[circ.ex$queryHits]
-  circ.ex.matrix = dcast.data.table(formula = fac~set,
-                                    fun.aggregate = sum,
-                                    fill = 0,
-                                    value.var = "nreads",
-                                    data = circ.ex)
-  circ.ex.matrix = circ.ex.matrix[match(names(circ.gr.reduced), circ.ex.matrix$fac)]
+  circ.ex <- merge.fos[, .(queryHits, fac)]
+  circ.ex$nreads <- values(circ.gr)[[column.name]][circ.ex$queryHits]
+  circ.ex$set <- circ.gr$set[circ.ex$queryHits]
+  circ.ex.matrix <- dcast.data.table(formula = fac~set,
+                                     fun.aggregate = sum,
+                                     fill = 0,
+                                     value.var = "nreads",
+                                     data = circ.ex)
+  circ.ex.matrix <- circ.ex.matrix[match(names(circ.gr.reduced), circ.ex.matrix$fac)]
 
   return(circ.ex.matrix)
 }
@@ -270,33 +270,33 @@ MungeColumn <- function(merge.fos, circ.gr, circ.gr.reduced, column.name) {
 #'
 #' @return a list
 #' @export
-ProcessLinear = function(dcircs, circ.gr.reduced, wobble){
+ProcessLinear <- function(dcircs, circ.gr.reduced, wobble){
 
-    lin.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs[["linear"]]),
+    lin.gr <-  makeGRangesFromDataFrame(as.data.frame(dcircs[["linear"]]),
                                        keep.extra.columns = TRUE)
-    circ.gr.s = resize(resize(circ.gr.reduced, fix = "start", width = 1),
-                       fix = "center", width = wobble)
-    circ.gr.e = resize(resize(circ.gr.reduced, fix = "end",   width = 1),
-                       fix = "center", width = wobble)
+    circ.gr.s <- resize(resize(circ.gr.reduced, fix = "start", width = 1),
+                        fix = "center", width = wobble)
+    circ.gr.e <- resize(resize(circ.gr.reduced, fix = "end",   width = 1),
+                        fix = "center", width = wobble)
 
-    cfos = data.table(as.matrix(findOverlaps(resize(lin.gr, fix = "start", width = 1),
-                                             circ.gr.e, ignore.strand = FALSE)))
-    cfoe = data.table(as.matrix(findOverlaps(resize(lin.gr, fix = "end",   width = 1),
-                                             circ.gr.s, ignore.strand = FALSE)))
+    cfos <- data.table(as.matrix(findOverlaps(resize(lin.gr, fix = "start", width = 1),
+                                              circ.gr.e, ignore.strand = FALSE)))
+    cfoe <- data.table(as.matrix(findOverlaps(resize(lin.gr, fix = "end",   width = 1),
+                                              circ.gr.s, ignore.strand = FALSE)))
 
-    cfos$nreads = lin.gr$n_reads[cfos$queryHits]
-    cfos$set = lin.gr$set[cfos$queryHits]
-    cfos$queryHits = factor(cfos$subjectHits, levels = 1:length(circ.gr.reduced))
-    cfos.cast = dcast.data.table(formula = queryHits~set, fun.aggregate = sum, fill = 0,
-                                 value.var = "nreads", data = cfos, drop = FALSE)
-    cfos.cast = cfos.cast[match(names(circ.gr.reduced), cfos.cast$queryHits)]
+    cfos$nreads <- lin.gr$n_reads[cfos$queryHits]
+    cfos$set <- lin.gr$set[cfos$queryHits]
+    cfos$queryHits <- factor(cfos$subjectHits, levels = 1:length(circ.gr.reduced))
+    cfos.cast <- dcast.data.table(formula = queryHits~set, fun.aggregate = sum, fill = 0,
+                                  value.var = "nreads", data = cfos, drop = FALSE)
+    cfos.cast <- cfos.cast[match(names(circ.gr.reduced), cfos.cast$queryHits)]
 
-    cfoe$nreads = lin.gr$n_reads[cfoe$queryHits]
-    cfoe$set = lin.gr$set[cfoe$queryHits]
-    cfoe$queryHits = factor(cfoe$subjectHits, levels = 1:length(circ.gr.reduced))
-    cfoe.cast = dcast.data.table(formula = queryHits~set, fun.aggregate = sum, fill = 0,
-                                 value.var = "nreads", data = cfoe, drop = FALSE)
-    cfoe.cast = cfoe.cast[match(names(circ.gr.reduced), cfoe.cast$queryHits)]
+    cfoe$nreads <- lin.gr$n_reads[cfoe$queryHits]
+    cfoe$set <- lin.gr$set[cfoe$queryHits]
+    cfoe$queryHits <- factor(cfoe$subjectHits, levels = 1:length(circ.gr.reduced))
+    cfoe.cast <- dcast.data.table(formula = queryHits~set, fun.aggregate = sum, fill = 0,
+                                  value.var = "nreads", data = cfoe, drop = FALSE)
+    cfoe.cast <- cfoe.cast[match(names(circ.gr.reduced), cfoe.cast$queryHits)]
 
     return(list(linear.start = as.matrix(cfos.cast[, -1, with = FALSE]),
                 linear.end   = as.matrix(cfoe.cast[, -1, with = FALSE])))

--- a/R/readData.R
+++ b/R/readData.R
@@ -110,7 +110,7 @@ setGeneric("summarizeCircs",
                     ...)
              standardGeneric("summarizeCircs"))
 
-#' @aliases summarizeCircs,data.frame-method
+#' @aliases summarizeCircs, data.frame-method
 #' @rdname summarizeCircs-methods
 setMethod("summarizeCircs", signature("data.frame"),
           function(colData, keep.linear, wobble, subs, qualfilter, keepCols){
@@ -118,7 +118,7 @@ setMethod("summarizeCircs", signature("data.frame"),
 
             # munge input
             # -------------------------------------- #
-            coldata.cnams = c("sample","filename")
+            coldata.cnams = c("sample", "filename")
             if(!all(coldata.cnams %in% colnames(colData)))
                stop(paste(setdiff(coldata.cnams, colnames(colData),
                             "is missing from colData")))
@@ -210,10 +210,10 @@ setMethod("summarizeCircs", signature("data.frame"),
 
 })
 
-#' @aliases summarizeCircs,character-method
+#' @aliases summarizeCircs, character-method
 #' @rdname summarizeCircs-methods
 setMethod("summarizeCircs", signature("character"),
-          function(colData, keep.linear, wobble, subs, qualfilter,keepCols){
+          function(colData, keep.linear, wobble, subs, qualfilter, keepCols){
 
             message("Constructing colData...")
             colData = data.frame(sample   = sub(".candidates.bed", "", basename(colData)),
@@ -247,7 +247,7 @@ MungeColumn <- function(merge.fos, circ.gr, circ.gr.reduced, column.name) {
     stop("unknown column name: ", column.name)
   }
 
-  circ.ex = merge.fos[,.(queryHits, fac)]
+  circ.ex = merge.fos[, .(queryHits, fac)]
   circ.ex$nreads = values(circ.gr)[[column.name]][circ.ex$queryHits]
   circ.ex$set = circ.gr$set[circ.ex$queryHits]
   circ.ex.matrix = dcast.data.table(formula = fac~set,
@@ -287,18 +287,18 @@ ProcessLinear = function(dcircs, circ.gr.reduced, wobble){
     cfos$nreads = lin.gr$n_reads[cfos$queryHits]
     cfos$set = lin.gr$set[cfos$queryHits]
     cfos$queryHits = factor(cfos$subjectHits, levels = 1:length(circ.gr.reduced))
-    cfos.cast = dcast.data.table(formula = queryHits~set, fun.aggregate = sum,fill = 0,
+    cfos.cast = dcast.data.table(formula = queryHits~set, fun.aggregate = sum, fill = 0,
                                  value.var = "nreads", data = cfos, drop = FALSE)
-    cfos.cast = cfos.cast[match(names(circ.gr.reduced),cfos.cast$queryHits)]
+    cfos.cast = cfos.cast[match(names(circ.gr.reduced), cfos.cast$queryHits)]
 
     cfoe$nreads = lin.gr$n_reads[cfoe$queryHits]
     cfoe$set = lin.gr$set[cfoe$queryHits]
     cfoe$queryHits = factor(cfoe$subjectHits, levels = 1:length(circ.gr.reduced))
-    cfoe.cast = dcast.data.table(formula = queryHits~set, fun.aggregate = sum,fill = 0,
+    cfoe.cast = dcast.data.table(formula = queryHits~set, fun.aggregate = sum, fill = 0,
                                  value.var = "nreads", data = cfoe, drop = FALSE)
-    cfoe.cast = cfoe.cast[match(names(circ.gr.reduced),cfoe.cast$queryHits)]
+    cfoe.cast = cfoe.cast[match(names(circ.gr.reduced), cfoe.cast$queryHits)]
 
-    return(list(linear.start = as.matrix(cfos.cast[,-1,with = FALSE]),
-                linear.end   = as.matrix(cfoe.cast[,-1,with = FALSE])))
+    return(list(linear.start = as.matrix(cfos.cast[, -1, with = FALSE]),
+                linear.end   = as.matrix(cfoe.cast[, -1, with = FALSE])))
 }
 

--- a/R/readData.R
+++ b/R/readData.R
@@ -137,7 +137,8 @@ setMethod("summarizeCircs", signature("data.frame"),
             dcircs$set <- factor(rep(names(circs), sapply(circs, nrow)), levels = names(circs))
 
             # process circular and linear if input is find_circ
-            if (!("SM_MS_SMS" %in% names(circs[[1]]))) { #TODO: find a better way to recognize CIRI2
+            # TODO: find a better way to recognize CIRI2
+            if (!("SM_MS_SMS" %in% names(circs[[1]]))) {
               # find_circ
               if (grepl("_circ_norm_", dcircs$name[1]) | grepl("_circ_circ_", dcircs$name[1])) {
                 message("funky naming scheme used, will convert _circ_norm_ to _norm_ and _circ_circ_ to _circ_ before everything crashes")
@@ -175,7 +176,8 @@ setMethod("summarizeCircs", signature("data.frame"),
             message("Fetching circular expression")
 
             assays <- list()
-            if (!("SM_MS_SMS" %in% names(circs[[1]]))) { #TODO: find a better way to recognize CIRI2
+            # TODO: find a better way to recognize CIRI2
+            if (!("SM_MS_SMS" %in% names(circs[[1]]))) {
 
               n_reads.dt <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_reads")
               n_uniq.dt  <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_uniq")

--- a/R/readData.R
+++ b/R/readData.R
@@ -22,7 +22,8 @@
 #' @return A data table.
 #'
 #' @export
-readCircs <- function(file, subs = "all", qualfilter = TRUE, keepCols = 1:6, ...) {
+readCircs <- function(file, subs = "all", qualfilter = TRUE, keepCols = 1:6,
+                      ...) {
 
   suppressWarnings(
     DT <- fread(file, sep = "\t", header = T) # maybe add colClasses later
@@ -37,14 +38,16 @@ readCircs <- function(file, subs = "all", qualfilter = TRUE, keepCols = 1:6, ...
     # ***due to find_circ.py logic of putting a header line
     #    in the middle of the output file, all columns are
     #    character after fread()
-    char.class <- c("chrom", "name", "strand", "tissues", "signal", "strandmatch", "category")
+    char.class <- c("chrom", "name", "strand", "tissues", "signal",
+                    "strandmatch", "category")
     for (col in setdiff(colnames(DT), char.class)){
       set(DT, j = col, value = as.integer(DT[[col]]))
     }
 
   } else if (ncol(DT) >= 21 & names(DT)[1] == "#chrom"){
     # read find_circ2
-    DT.lin <- fread(sub("circ_splice_sites.bed$", "lin_splice_sites.bed", file), sep = "\t", header = T)
+    DT.lin <- fread(sub("circ_splice_sites.bed$", "lin_splice_sites.bed", file),
+                    sep = "\t", header = T)
     DT.lin$name <- sub("lin", "norm", DT.lin$name)
     DT <- rbind(DT.lin, DT)
 
@@ -55,7 +58,9 @@ readCircs <- function(file, subs = "all", qualfilter = TRUE, keepCols = 1:6, ...
     DT <- DT[!grepl("#", DT$chrom)]
   } else if (ncol(DT) == 12 & names(DT)[1] == "circRNA_ID") {
     # read CIRI2
-    setnames(DT, c("name", "chrom", "start", "end", "n_reads", "SM_MS_SMS", "n_reads_nonjunction", "junction_reads_ratio", "circRNA_type", "gene_id", "strand", "junction_reads_ID"))
+    setnames(DT, c("name", "chrom", "start", "end", "n_reads", "SM_MS_SMS",
+                   "n_reads_nonjunction", "junction_reads_ratio",
+                   "circRNA_type", "gene_id", "strand", "junction_reads_ID"))
   }
 
 
@@ -134,41 +139,62 @@ setMethod("summarizeCircs", signature("data.frame"),
             names(circs) <- colData$sample
 
             dcircs <- rbindlist(circs)
-            dcircs$set <- factor(rep(names(circs), sapply(circs, nrow)), levels = names(circs))
+            dcircs$set <- factor(rep(names(circs), sapply(circs, nrow)),
+                                 levels = names(circs))
 
             # process circular and linear if input is find_circ
             # TODO: find a better way to recognize CIRI2
             if (!("SM_MS_SMS" %in% names(circs[[1]]))) {
               # find_circ
-              if (grepl("_circ_norm_", dcircs$name[1]) | grepl("_circ_circ_", dcircs$name[1])) {
-                message("funky naming scheme used, will convert _circ_norm_ to _norm_ and _circ_circ_ to _circ_ before everything crashes")
+              if (grepl("_circ_norm_", dcircs$name[1]) |
+                  grepl("_circ_circ_", dcircs$name[1])) {
+                message(paste("funky naming scheme used, will convert",
+                              "_circ_norm_ to _norm_ and _circ_circ_ to _circ_",
+                              "before everything crashes"))
                 dcircs$name <- sub("_circ_norm_", "_norm_", dcircs$name)
                 dcircs$name <- sub("_circ_circ_", "_circ_", dcircs$name)
               }
-              dcircs$type <- ifelse(grepl("circ", dcircs$name), "circ", "linear")
+              dcircs$type <- ifelse(grepl("circ", dcircs$name), "circ",
+                                    "linear")
 
               dcircs <- split(dcircs, dcircs$type)
 
-              circ.gr <-  makeGRangesFromDataFrame(as.data.frame(dcircs[["circ"]]), keep.extra.columns = TRUE)
+              circ.gr <-
+                makeGRangesFromDataFrame(as.data.frame(dcircs[["circ"]]),
+                                         keep.extra.columns = TRUE)
             } else {
               # CIRI2
-              circ.gr <-  makeGRangesFromDataFrame(as.data.frame(dcircs), keep.extra.columns = TRUE)
+              circ.gr <-  makeGRangesFromDataFrame(as.data.frame(dcircs),
+                                                   keep.extra.columns = TRUE)
             }
 
             # prepare the wobble
             # -------------------------------------- #
-            circ.gr.s <- resize(resize(circ.gr, fix = "start", width = 1), fix = "center", width = wobble)
-            circ.gr.e <- resize(resize(circ.gr, fix = "end",   width = 1), fix = "center", width = wobble)
+            circ.gr.s <- resize(resize(circ.gr, fix = "start", width = 1),
+                                fix = "center", width = wobble)
+            circ.gr.e <- resize(resize(circ.gr, fix = "end",   width = 1),
+                                fix = "center", width = wobble)
 
-            circ.fos <- data.table(as.matrix(findOverlaps(circ.gr.s, reduce(circ.gr.s, ignore.strand = FALSE))))
-            circ.foe <- data.table(as.matrix(findOverlaps(circ.gr.e, reduce(circ.gr.e, ignore.strand = FALSE))))
+            circ.fos <-
+              data.table(as.matrix(findOverlaps(circ.gr.s,
+                                                reduce(circ.gr.s,
+                                                       ignore.strand = FALSE))))
+            circ.foe <-
+              data.table(as.matrix(findOverlaps(circ.gr.e,
+                                                reduce(circ.gr.e,
+                                                       ignore.strand = FALSE))))
 
             merge.fos <- merge(circ.fos, circ.foe, by = "queryHits", all = TRUE)
-            merge.fos$fac <- with(merge.fos, as.numeric(factor(paste(subjectHits.x, subjectHits.y))))
+            merge.fos$fac <- with(merge.fos,
+                                  as.numeric(factor(paste(subjectHits.x,
+                                                          subjectHits.y))))
 
-            #circ.gr.reduced <- sort(unlist(range(split(circ.gr, merge.fos$fac), ignore.strand = FALSE)))
-            # TODO: wobble logic is naive, should be improved to select the best expressed circRNA as a referent one
-            circ.gr.reduced <- unlist(range(split(circ.gr, merge.fos$fac), ignore.strand = FALSE))
+            #circ.gr.reduced <- sort(unlist(range(split(circ.gr, merge.fos$fac),
+            #                                     ignore.strand = FALSE)))
+            # TODO: wobble logic is naive, should be improved to select the best
+            # expressed circRNA as a referent one
+            circ.gr.reduced <- unlist(range(split(circ.gr, merge.fos$fac),
+                                            ignore.strand = FALSE))
 
             # prepare the assays object
             # TODO: this screams refactoring
@@ -179,15 +205,18 @@ setMethod("summarizeCircs", signature("data.frame"),
             # TODO: find a better way to recognize CIRI2
             if (!("SM_MS_SMS" %in% names(circs[[1]]))) {
 
-              n_reads.dt <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_reads")
-              n_uniq.dt  <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_uniq")
+              n_reads.dt <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced,
+                                        "n_reads")
+              n_uniq.dt  <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced,
+                                        "n_uniq")
 
               assays$circ      <- as.matrix(n_reads.dt[, -1, with = FALSE])
               assays$circ.uniq <- as.matrix( n_uniq.dt[, -1, with = FALSE])
 
             } else {
 
-              n_reads.dt <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced, "n_reads")
+              n_reads.dt <- MungeColumn(merge.fos, circ.gr, circ.gr.reduced,
+                                        "n_reads")
               assays$circ      <- as.matrix(n_reads.dt[, -1, with = FALSE])
 
             }
@@ -218,7 +247,8 @@ setMethod("summarizeCircs", signature("character"),
           function(colData, keep.linear, wobble, subs, qualfilter, keepCols){
 
             message("Constructing colData...")
-            colData <- data.frame(sample   = sub(".candidates.bed", "", basename(colData)),
+            colData <- data.frame(sample   = sub(".candidates.bed", "",
+                                                 basename(colData)),
                                   filename = colData,
                                   stringsAsFactors = FALSE)
 
@@ -233,8 +263,10 @@ setMethod("summarizeCircs", signature("character"),
 
 #' Title
 #'
-#' Function that, based on circRNA candidate list and collapsed circRNA candidate list
-#' summarizes a numeric input column into a matrix that can be hooked to SummarizedExperiment
+#' Function that, based on circRNA candidate list and collapsed circRNA
+#' candidate list
+#' summarizes a numeric input column into a matrix that can be hooked to
+#' SummarizedExperiment
 #'
 #' @param merge.fos merge fos
 #' @param circ.gr circs
@@ -257,7 +289,8 @@ MungeColumn <- function(merge.fos, circ.gr, circ.gr.reduced, column.name) {
                                      fill = 0,
                                      value.var = "nreads",
                                      data = circ.ex)
-  circ.ex.matrix <- circ.ex.matrix[match(names(circ.gr.reduced), circ.ex.matrix$fac)]
+  circ.ex.matrix <- circ.ex.matrix[match(names(circ.gr.reduced),
+                                         circ.ex.matrix$fac)]
 
   return(circ.ex.matrix)
 }
@@ -281,23 +314,31 @@ ProcessLinear <- function(dcircs, circ.gr.reduced, wobble){
     circ.gr.e <- resize(resize(circ.gr.reduced, fix = "end",   width = 1),
                         fix = "center", width = wobble)
 
-    cfos <- data.table(as.matrix(findOverlaps(resize(lin.gr, fix = "start", width = 1),
-                                              circ.gr.e, ignore.strand = FALSE)))
-    cfoe <- data.table(as.matrix(findOverlaps(resize(lin.gr, fix = "end",   width = 1),
-                                              circ.gr.s, ignore.strand = FALSE)))
+    cfos <- data.table(as.matrix(findOverlaps(resize(lin.gr, fix = "start",
+                                                     width = 1),
+                                              circ.gr.e,
+                                              ignore.strand = FALSE)))
+    cfoe <- data.table(as.matrix(findOverlaps(resize(lin.gr, fix = "end",
+                                                     width = 1),
+                                              circ.gr.s,
+                                              ignore.strand = FALSE)))
 
     cfos$nreads <- lin.gr$n_reads[cfos$queryHits]
     cfos$set <- lin.gr$set[cfos$queryHits]
-    cfos$queryHits <- factor(cfos$subjectHits, levels = 1:length(circ.gr.reduced))
-    cfos.cast <- dcast.data.table(formula = queryHits~set, fun.aggregate = sum, fill = 0,
-                                  value.var = "nreads", data = cfos, drop = FALSE)
+    cfos$queryHits <- factor(cfos$subjectHits,
+                             levels = 1:length(circ.gr.reduced))
+    cfos.cast <- dcast.data.table(formula = queryHits~set, fun.aggregate = sum,
+                                  fill = 0, value.var = "nreads", data = cfos,
+                                  drop = FALSE)
     cfos.cast <- cfos.cast[match(names(circ.gr.reduced), cfos.cast$queryHits)]
 
     cfoe$nreads <- lin.gr$n_reads[cfoe$queryHits]
     cfoe$set <- lin.gr$set[cfoe$queryHits]
-    cfoe$queryHits <- factor(cfoe$subjectHits, levels = 1:length(circ.gr.reduced))
-    cfoe.cast <- dcast.data.table(formula = queryHits~set, fun.aggregate = sum, fill = 0,
-                                  value.var = "nreads", data = cfoe, drop = FALSE)
+    cfoe$queryHits <- factor(cfoe$subjectHits,
+                             levels = 1:length(circ.gr.reduced))
+    cfoe.cast <- dcast.data.table(formula = queryHits~set, fun.aggregate = sum,
+                                  fill = 0, value.var = "nreads", data = cfoe,
+                                  drop = FALSE)
     cfoe.cast <- cfoe.cast[match(names(circ.gr.reduced), cfoe.cast$queryHits)]
 
     return(list(linear.start = as.matrix(cfos.cast[, -1, with = FALSE]),

--- a/R/readData.R
+++ b/R/readData.R
@@ -29,7 +29,7 @@ readCircs <- function(file, subs = "all", qualfilter = TRUE, keepCols = 1:6, ...
   )
 
   # try to figure out what tool the data are coming from
-  if (ncol(DT) == 19 & names(DT)[1] == '# chrom') {
+  if (ncol(DT) == 19 & names(DT)[1] == "# chrom") {
     # read find_circ
     setnames(DT, "# chrom", "chrom")
     DT <- DT[!grepl("#", DT$chrom)]
@@ -37,12 +37,12 @@ readCircs <- function(file, subs = "all", qualfilter = TRUE, keepCols = 1:6, ...
     # ***due to find_circ.py logic of putting a header line
     #    in the middle of the output file, all columns are
     #    character after fread()
-    char.class = c('chrom', 'name', 'strand', 'tissues', 'signal', 'strandmatch', 'category')
+    char.class = c("chrom", "name", "strand", "tissues", "signal", "strandmatch", "category")
     for (col in setdiff(colnames(DT), char.class)){
       set(DT, j = col, value = as.integer(DT[[col]]))
     }
 
-  } else if (ncol(DT) >= 21 & names(DT)[1] == '#chrom'){
+  } else if (ncol(DT) >= 21 & names(DT)[1] == "#chrom"){
     # read find_circ2
     DT.lin <- fread(sub("circ_splice_sites.bed$", "lin_splice_sites.bed", file), sep = "\t", header = T)
     DT.lin$name <- sub("lin", "norm", DT.lin$name)
@@ -53,9 +53,9 @@ readCircs <- function(file, subs = "all", qualfilter = TRUE, keepCols = 1:6, ...
     setnames(DT, names(DT)[5], "n_reads") # TODO: this is dirty af
 
     DT <- DT[!grepl("#", DT$chrom)]
-  } else if (ncol(DT) == 12 & names(DT)[1] == 'circRNA_ID') {
+  } else if (ncol(DT) == 12 & names(DT)[1] == "circRNA_ID") {
     # read CIRI2
-    setnames(DT, c('name', 'chrom', 'start', 'end', 'n_reads', 'SM_MS_SMS', 'n_reads_nonjunction', 'junction_reads_ratio', 'circRNA_type', 'gene_id', 'strand', 'junction_reads_ID'))
+    setnames(DT, c("name", "chrom", "start", "end", "n_reads", "SM_MS_SMS", "n_reads_nonjunction", "junction_reads_ratio", "circRNA_type", "gene_id", "strand", "junction_reads_ID"))
   }
 
 
@@ -104,7 +104,7 @@ setGeneric("summarizeCircs",
            function(colData = NULL,
                     keep.linear = TRUE,
                     wobble = 5,
-                    subs = 'all',
+                    subs = "all",
                     qualfilter = TRUE,
                     keepCols = 1:6,
                     ...)
@@ -118,15 +118,15 @@ setMethod("summarizeCircs", signature("data.frame"),
 
             # munge input
             # -------------------------------------- #
-            coldata.cnams = c('sample','filename')
+            coldata.cnams = c("sample","filename")
             if(!all(coldata.cnams %in% colnames(colData)))
                stop(paste(setdiff(coldata.cnams, colnames(colData),
-                            'is missing from colData')))
+                            "is missing from colData")))
 
             circ.files = as.character(colData$filename)
 
             if(!all(file.exists(circ.files)))
-              stop('Supplied circ files do not exist')
+              stop("Supplied circ files do not exist")
 
             # load circs
             # -------------------------------------- #
@@ -140,15 +140,15 @@ setMethod("summarizeCircs", signature("data.frame"),
             if (!("SM_MS_SMS" %in% names(circs[[1]]))) { #TODO: find a better way to recognize CIRI2
               # find_circ
               if (grepl("_circ_norm_", dcircs$name[1]) | grepl("_circ_circ_", dcircs$name[1])) {
-                message('funky naming scheme used, will convert _circ_norm_ to _norm_ and _circ_circ_ to _circ_ before everything crashes')
+                message("funky naming scheme used, will convert _circ_norm_ to _norm_ and _circ_circ_ to _circ_ before everything crashes")
                 dcircs$name <- sub("_circ_norm_", "_norm_", dcircs$name)
                 dcircs$name <- sub("_circ_circ_", "_circ_", dcircs$name)
               }
-              dcircs$type = ifelse(grepl('circ', dcircs$name), 'circ', 'linear')
+              dcircs$type = ifelse(grepl("circ", dcircs$name), "circ", "linear")
 
               dcircs = split(dcircs, dcircs$type)
 
-              circ.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs[['circ']]), keep.extra.columns = TRUE)
+              circ.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs[["circ"]]), keep.extra.columns = TRUE)
             } else {
               # CIRI2
               circ.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs), keep.extra.columns = TRUE)
@@ -156,13 +156,13 @@ setMethod("summarizeCircs", signature("data.frame"),
 
             # prepare the wobble
             # -------------------------------------- #
-            circ.gr.s = resize(resize(circ.gr, fix = 'start', width = 1), fix = 'center', width = wobble)
-            circ.gr.e = resize(resize(circ.gr, fix = 'end',   width = 1), fix = 'center', width = wobble)
+            circ.gr.s = resize(resize(circ.gr, fix = "start", width = 1), fix = "center", width = wobble)
+            circ.gr.e = resize(resize(circ.gr, fix = "end",   width = 1), fix = "center", width = wobble)
 
             circ.fos = data.table(as.matrix(findOverlaps(circ.gr.s, reduce(circ.gr.s, ignore.strand = FALSE))))
             circ.foe = data.table(as.matrix(findOverlaps(circ.gr.e, reduce(circ.gr.e, ignore.strand = FALSE))))
 
-            merge.fos = merge(circ.fos, circ.foe, by = 'queryHits', all = TRUE)
+            merge.fos = merge(circ.fos, circ.foe, by = "queryHits", all = TRUE)
             merge.fos$fac = with(merge.fos, as.numeric(factor(paste(subjectHits.x, subjectHits.y))))
 
             #circ.gr.reduced = sort(unlist(range(split(circ.gr, merge.fos$fac), ignore.strand = FALSE)))
@@ -172,7 +172,7 @@ setMethod("summarizeCircs", signature("data.frame"),
             # prepare the assays object
             # TODO: this screams refactoring
             # -------------------------------------- #
-            message('Fetching circular expression')
+            message("Fetching circular expression")
 
             assays = list()
             if (!("SM_MS_SMS" %in% names(circs[[1]]))) { #TODO: find a better way to recognize CIRI2
@@ -191,14 +191,14 @@ setMethod("summarizeCircs", signature("data.frame"),
             }
 
             if(keep.linear == TRUE){
-              message('Processing linear transcripts')
+              message("Processing linear transcripts")
               linear = ProcessLinear(dcircs, circ.gr.reduced, wobble)
               assays = c(assays, linear)
             }
 
 
 
-            if(class(colData) == 'data.frame')
+            if(class(colData) == "data.frame")
                 colData = DataFrame(colData)
 
 
@@ -215,8 +215,8 @@ setMethod("summarizeCircs", signature("data.frame"),
 setMethod("summarizeCircs", signature("character"),
           function(colData, keep.linear, wobble, subs, qualfilter,keepCols){
 
-            message('Constructing colData...')
-            colData = data.frame(sample   = sub('.candidates.bed', '', basename(colData)),
+            message("Constructing colData...")
+            colData = data.frame(sample   = sub(".candidates.bed", "", basename(colData)),
                                  filename = colData,
                                  stringsAsFactors = FALSE)
 
@@ -244,7 +244,7 @@ setMethod("summarizeCircs", signature("character"),
 MungeColumn <- function(merge.fos, circ.gr, circ.gr.reduced, column.name) {
 
   if (!(column.name %in% colnames(elementMetadata(circ.gr)))) {
-    stop('unknown column name: ', column.name)
+    stop("unknown column name: ", column.name)
   }
 
   circ.ex = merge.fos[,.(queryHits, fac)]
@@ -253,7 +253,7 @@ MungeColumn <- function(merge.fos, circ.gr, circ.gr.reduced, column.name) {
   circ.ex.matrix = dcast.data.table(formula = fac~set,
                                     fun.aggregate = sum,
                                     fill = 0,
-                                    value.var = 'nreads',
+                                    value.var = "nreads",
                                     data = circ.ex)
   circ.ex.matrix = circ.ex.matrix[match(names(circ.gr.reduced), circ.ex.matrix$fac)]
 
@@ -272,30 +272,30 @@ MungeColumn <- function(merge.fos, circ.gr, circ.gr.reduced, column.name) {
 #' @export
 ProcessLinear = function(dcircs, circ.gr.reduced, wobble){
 
-    lin.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs[['linear']]),
+    lin.gr =  makeGRangesFromDataFrame(as.data.frame(dcircs[["linear"]]),
                                        keep.extra.columns = TRUE)
-    circ.gr.s = resize(resize(circ.gr.reduced, fix = 'start', width = 1),
-                       fix = 'center', width = wobble)
-    circ.gr.e = resize(resize(circ.gr.reduced, fix = 'end',   width = 1),
-                       fix = 'center', width = wobble)
+    circ.gr.s = resize(resize(circ.gr.reduced, fix = "start", width = 1),
+                       fix = "center", width = wobble)
+    circ.gr.e = resize(resize(circ.gr.reduced, fix = "end",   width = 1),
+                       fix = "center", width = wobble)
 
-    cfos = data.table(as.matrix(findOverlaps(resize(lin.gr, fix = 'start', width = 1),
+    cfos = data.table(as.matrix(findOverlaps(resize(lin.gr, fix = "start", width = 1),
                                              circ.gr.e, ignore.strand = FALSE)))
-    cfoe = data.table(as.matrix(findOverlaps(resize(lin.gr, fix = 'end',   width = 1),
+    cfoe = data.table(as.matrix(findOverlaps(resize(lin.gr, fix = "end",   width = 1),
                                              circ.gr.s, ignore.strand = FALSE)))
 
     cfos$nreads = lin.gr$n_reads[cfos$queryHits]
     cfos$set = lin.gr$set[cfos$queryHits]
     cfos$queryHits = factor(cfos$subjectHits, levels = 1:length(circ.gr.reduced))
     cfos.cast = dcast.data.table(formula = queryHits~set, fun.aggregate = sum,fill = 0,
-                                 value.var = 'nreads', data = cfos, drop = FALSE)
+                                 value.var = "nreads", data = cfos, drop = FALSE)
     cfos.cast = cfos.cast[match(names(circ.gr.reduced),cfos.cast$queryHits)]
 
     cfoe$nreads = lin.gr$n_reads[cfoe$queryHits]
     cfoe$set = lin.gr$set[cfoe$queryHits]
     cfoe$queryHits = factor(cfoe$subjectHits, levels = 1:length(circ.gr.reduced))
     cfoe.cast = dcast.data.table(formula = queryHits~set, fun.aggregate = sum,fill = 0,
-                                 value.var = 'nreads', data = cfoe, drop = FALSE)
+                                 value.var = "nreads", data = cfoe, drop = FALSE)
     cfoe.cast = cfoe.cast[match(names(circ.gr.reduced),cfoe.cast$queryHits)]
 
     return(list(linear.start = as.matrix(cfos.cast[,-1,with = FALSE]),

--- a/R/readData.R
+++ b/R/readData.R
@@ -119,13 +119,13 @@ setMethod("summarizeCircs", signature("data.frame"),
             # munge input
             # -------------------------------------- #
             coldata.cnams <- c("sample", "filename")
-            if(!all(coldata.cnams %in% colnames(colData)))
+            if (!all(coldata.cnams %in% colnames(colData)))
                stop(paste(setdiff(coldata.cnams, colnames(colData),
                             "is missing from colData")))
 
             circ.files <- as.character(colData$filename)
 
-            if(!all(file.exists(circ.files)))
+            if (!all(file.exists(circ.files)))
               stop("Supplied circ files do not exist")
 
             # load circs
@@ -190,7 +190,7 @@ setMethod("summarizeCircs", signature("data.frame"),
 
             }
 
-            if(keep.linear == TRUE){
+            if (keep.linear == TRUE){
               message("Processing linear transcripts")
               linear <- ProcessLinear(dcircs, circ.gr.reduced, wobble)
               assays <- c(assays, linear)
@@ -198,7 +198,7 @@ setMethod("summarizeCircs", signature("data.frame"),
 
 
 
-            if(class(colData) == "data.frame")
+            if (class(colData) == "data.frame")
                 colData <- DataFrame(colData)
 
 

--- a/R/readData.R
+++ b/R/readData.R
@@ -303,4 +303,3 @@ ProcessLinear <- function(dcircs, circ.gr.reduced, wobble){
     return(list(linear.start = as.matrix(cfos.cast[, -1, with = FALSE]),
                 linear.end   = as.matrix(cfoe.cast[, -1, with = FALSE])))
 }
-

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -29,8 +29,11 @@ setMethod("resTable",
             setnames(DT, "seqnames", "chr")
             for (i in 1:length(colData(se)$sample)) {
 
-              DT <- cbind(DT, sapply(names(assays(se)), function(x) assays(se)[[x]][, i]))
-              setnames(DT, tail(names(DT), length(assays(se))), paste0(colData(se)$sample[i], "_", tail(names(DT), length(assays(se)))))
+              DT <- cbind(DT, sapply(names(assays(se)),
+                                     function(x) assays(se)[[x]][, i]))
+              setnames(DT, tail(names(DT), length(assays(se))),
+                       paste0(colData(se)$sample[i], "_",
+                              tail(names(DT), length(assays(se)))))
 
             }
 

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -20,7 +20,7 @@ setGeneric("resTable",
                     ...)
            standardGeneric("resTable"))
 
-#' @aliases resTable,RangedSummarizedExperiment-method
+#' @aliases resTable, RangedSummarizedExperiment-method
 #' @rdname resTable-methods
 setMethod("resTable",
           signature("RangedSummarizedExperiment"),
@@ -29,7 +29,7 @@ setMethod("resTable",
             setnames(DT, "seqnames", "chr")
             for (i in 1:length(colData(se)$sample)) {
 
-              DT <- cbind(DT, sapply(names(assays(se)), function(x) assays(se)[[x]][,i]))
+              DT <- cbind(DT, sapply(names(assays(se)), function(x) assays(se)[[x]][, i]))
               setnames(DT, tail(names(DT), length(assays(se))), paste0(colData(se)$sample[i], "_", tail(names(DT), length(assays(se)))))
 
             }

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -24,7 +24,7 @@ setGeneric("resTable",
 #' @rdname resTable-methods
 setMethod("resTable",
           signature("RangedSummarizedExperiment"),
-          definition=function(se, ...) {
+          definition = function(se, ...) {
             DT <- data.table(as.data.frame(rowRanges(se)))
             setnames(DT, "seqnames", "chr")
             for (i in 1:length(colData(se)$sample)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,12 +7,12 @@
 #' @export
 #'
 testCoordinateIndexing <- function(g1, g2) {
-  start.hits <- c(equal    = sum( start(g1)      %in% start(g2)),
-                  plusone  = sum((start(g1) + 1) %in% start(g2)),
-                  minusone = sum((start(g1) - 1) %in% start(g2)))
-  end.hits   <- c(equal    = sum( end(g1)        %in%   end(g2)),
-                  plusone  = sum((end(g1) + 1)   %in%   end(g2)),
-                  minusone = sum((end(g1) - 1)   %in%   end(g2)))
+  start.hits <- c(equal    = sum(  start(g1)      %in% start(g2)),
+                  plusone  = sum( (start(g1) + 1) %in% start(g2)),
+                  minusone = sum( (start(g1) - 1) %in% start(g2)))
+  end.hits   <- c(equal    = sum(    end(g1)      %in%   end(g2)),
+                  plusone  = sum(   (end(g1) + 1) %in%   end(g2)),
+                  minusone = sum(   (end(g1) - 1) %in%   end(g2)))
   if        (start.hits["plusone"] > sum(start.hits) * 0.9) {
     warning(round(start.hits["plusone"] / sum(start.hits) * 100, 2),  "% start coordinates are off by one when compared to annotation. Looks like input is zero- and annotation is one-based.")
   } else if (start.hits["minusone"] > sum(start.hits) * 0.9) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,16 +13,16 @@ testCoordinateIndexing <- function(g1, g2) {
   end.hits   <- c(equal    = sum( end(g1)        %in%   end(g2)),
                   plusone  = sum((end(g1) + 1)   %in%   end(g2)),
                   minusone = sum((end(g1) - 1)   %in%   end(g2)))
-  if        (start.hits["plusone"] > sum(start.hits)*0.9) {
-    warning(round(start.hits["plusone"]/sum(start.hits)*100, 2),  "% start coordinates are off by one when compared to annotation. Looks like input is zero- and annotation is one-based.")
-  } else if (start.hits["minusone"] > sum(start.hits)*0.9) {
-    warning(round(start.hits["minusone"]/sum(start.hits)*100, 2), "% start coordinates are off by one. Looks like input is one- and annotation is zero-based.")
-  } else if (start.hits["minusone"] > sum(start.hits)*0.9) {
-    warning(round(end.hits["plusone"]/sum(end.hits)*100, 2),  "% end coordinates are off by one when compared to annotation. Looks like input is zero- and annotation is one-based.")
-  } else if (  end.hits["plusone"]  > sum(end.hits)*0.9) {
-    warning(round(end.hits["minusone"]/sum(end.hits)*100, 2),  "% start coordinates are off by one when compared to annotation. Looks like input is one- and annotation is zero-based.")
+  if        (start.hits["plusone"] > sum(start.hits) * 0.9) {
+    warning(round(start.hits["plusone"] / sum(start.hits) * 100, 2),  "% start coordinates are off by one when compared to annotation. Looks like input is zero- and annotation is one-based.")
+  } else if (start.hits["minusone"] > sum(start.hits) * 0.9) {
+    warning(round(start.hits["minusone"] / sum(start.hits) * 100, 2), "% start coordinates are off by one. Looks like input is one- and annotation is zero-based.")
+  } else if (start.hits["minusone"] > sum(start.hits) * 0.9) {
+    warning(round(end.hits["plusone"] / sum(end.hits) * 100, 2),  "% end coordinates are off by one when compared to annotation. Looks like input is zero- and annotation is one-based.")
+  } else if (  end.hits["plusone"]  > sum(end.hits) * 0.9) {
+    warning(round(end.hits["minusone"] / sum(end.hits) * 100, 2),  "% start coordinates are off by one when compared to annotation. Looks like input is one- and annotation is zero-based.")
   }
 
-  return(list(start.hits=start.hits,
-              end.hits=end.hits))
+  return(list(start.hits = start.hits,
+              end.hits = end.hits))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,13 +14,24 @@ testCoordinateIndexing <- function(g1, g2) {
                   plusone  = sum(   (end(g1) + 1) %in%   end(g2)),
                   minusone = sum(   (end(g1) - 1) %in%   end(g2)))
   if        (start.hits["plusone"] > sum(start.hits) * 0.9) {
-    warning(round(start.hits["plusone"] / sum(start.hits) * 100, 2),  "% start coordinates are off by one when compared to annotation. Looks like input is zero- and annotation is one-based.")
+    warning(round(start.hits["plusone"] / sum(start.hits) * 100, 2),
+            paste("% start coordinates are off by one when compared to",
+                  "annotation. Looks like input is zero- and annotation is",
+                  "one-based."))
   } else if (start.hits["minusone"] > sum(start.hits) * 0.9) {
-    warning(round(start.hits["minusone"] / sum(start.hits) * 100, 2), "% start coordinates are off by one. Looks like input is one- and annotation is zero-based.")
+    warning(round(start.hits["minusone"] / sum(start.hits) * 100, 2),
+            paste("% start coordinates are off by one. Looks like input is",
+                  "one- and annotation is zero-based."))
   } else if (start.hits["minusone"] > sum(start.hits) * 0.9) {
-    warning(round(end.hits["plusone"] / sum(end.hits) * 100, 2),  "% end coordinates are off by one when compared to annotation. Looks like input is zero- and annotation is one-based.")
+    warning(round(end.hits["plusone"] / sum(end.hits) * 100, 2),
+            paste("% end coordinates are off by one when compared to",
+                  "annotation. Looks like input is zero- and annotation is",
+                  "one-based."))
   } else if (  end.hits["plusone"]  > sum(end.hits) * 0.9) {
-    warning(round(end.hits["minusone"] / sum(end.hits) * 100, 2),  "% start coordinates are off by one when compared to annotation. Looks like input is one- and annotation is zero-based.")
+    warning(round(end.hits["minusone"] / sum(end.hits) * 100, 2),
+            paste("% start coordinates are off by one when compared to",
+                  "annotation. Looks like input is one- and annotation is",
+                  "zero-based."))
   }
 
   return(list(start.hits = start.hits,

--- a/R/visualize.R
+++ b/R/visualize.R
@@ -26,8 +26,8 @@ setGeneric("histogram",
 #' @rdname histogram-methods
 setMethod("histogram",
           signature("RangedSummarizedExperiment"),
-          definition=function(se, binwidth = 0.7, ...) {
-            DT <- data.table(n_reads=rowSums(assays(se)$circ))
+          definition = function(se, binwidth = 0.7, ...) {
+            DT <- data.table(n_reads = rowSums(assays(se)$circ))
 
             p <- ggplot(DT, aes(x = n_reads)) +
               geom_histogram(binwidth = binwidth) +
@@ -36,10 +36,10 @@ setMethod("histogram",
               scale_y_continuous(breaks = c(0, 1, 10, 50, 100, 250, 500, 750, 1000, 2000, 3000)) +
               xlab("#reads on head-to-tail splice junction") +
               ylab("#circRNAs") +
-              theme(axis.title.y = element_text(size=20),
-                    axis.title.x = element_text(size=20),
-                    axis.text.x = element_text(size=16),
-                    axis.text.y = element_text(size=16))
+              theme(axis.title.y = element_text(size = 20),
+                    axis.title.x = element_text(size = 20),
+                    axis.text.x = element_text(size = 16),
+                    axis.text.y = element_text(size = 16))
 
             return(p)
 
@@ -73,11 +73,11 @@ setGeneric("annotPie",
 #' @rdname annotPie-methods
 setMethod("annotPie",
           signature("RangedSummarizedExperiment"),
-          definition=function(se, other.threshold = 0.02, ...) {
+          definition = function(se, other.threshold = 0.02, ...) {
 
             if (other.threshold < 1) {
 
-              thresh <- round(other.threshold*nrow(se))
+              thresh <- round(other.threshold * nrow(se))
 
             } else {
 
@@ -101,22 +101,22 @@ setMethod("annotPie",
               geom_bar(width = 1) +
               xlab("") +
               ylab("") +
-              theme(	axis.line=element_blank(),
-                     axis.text.x=element_blank(),
-                     axis.text.y=element_blank(),
-                     axis.ticks=element_blank(),
-                     axis.title.x=element_blank(),
-                     axis.title.y=element_blank(),
-                     panel.background=element_blank(),
-                     panel.border=element_blank(),
-                     panel.grid.major=element_blank(),
-                     panel.grid.minor=element_blank(),
-                     plot.background=element_blank(),
-                     legend.title=element_blank()) +
+              theme( axis.line = element_blank(),
+                     axis.text.x = element_blank(),
+                     axis.text.y = element_blank(),
+                     axis.ticks = element_blank(),
+                     axis.title.x = element_blank(),
+                     axis.title.y = element_blank(),
+                     panel.background = element_blank(),
+                     panel.border = element_blank(),
+                     panel.grid.major = element_blank(),
+                     panel.grid.minor = element_blank(),
+                     plot.background = element_blank(),
+                     legend.title = element_blank()) +
               coord_polar(theta = "y")
 
             if (nlevels(tmpdf$feature) <= 9) {
-              pie <- pie + scale_fill_manual(values = rev(brewer.pal(name="Blues", n=nlevels(tmpdf$feature))))
+              pie <- pie + scale_fill_manual(values = rev(brewer.pal(name = "Blues", n = nlevels(tmpdf$feature))))
             }
 
             return(pie)
@@ -147,7 +147,7 @@ setGeneric("uniqReadsQC",
 #' @rdname uniqReadsQC-methods
 setMethod("uniqReadsQC",
           signature("RangedSummarizedExperiment"),
-          definition=function(se, sample) {
+          definition = function(se, sample) {
 
             # this makes sense only for find_circ analyses,
             # CIRI does not report unique reads
@@ -169,18 +169,18 @@ setMethod("uniqReadsQC",
 
             tmp.dt <- data.table(totals = totals,
                                  uniqs  = uniqs,
-                                 LFC    = log2(totals/uniqs))
+                                 LFC    = log2(totals / uniqs))
 
             p <- ggplot(tmp.dt, aes(x = totals, y = LFC)) +
                   geom_point() +
                   xlab("#reads, total") +
                   ylab("log2(#reads_total / #reads_unique)") +
                   ggtitle(SMPL) +
-                  theme(axis.title.y = element_text(size=20),
-                        axis.title.x = element_text(size=20),
-                        axis.text.x  = element_text(size=16),
-                        axis.text.y  = element_text(size=16),
-                        plot.title   = element_text(size=20, hjust=0.5))
+                  theme(axis.title.y = element_text(size = 20),
+                        axis.title.x = element_text(size = 20),
+                        axis.text.x  = element_text(size = 16),
+                        axis.text.y  = element_text(size = 16),
+                        plot.title   = element_text(size = 20, hjust = 0.5))
 
 
             return(p)

--- a/R/visualize.R
+++ b/R/visualize.R
@@ -152,10 +152,10 @@ setMethod("uniqReadsQC",
             # this makes sense only for find_circ analyses,
             # CIRI does not report unique reads
             if (!("circ.uniq" %in% names(assays(se)))) {
-              stop('circ.uniq assay does not exist')
+              stop("circ.uniq assay does not exist")
             }
             if (sample != "all" & !(sample %in% colnames(se))) {
-              stop(sample, ' is not a valid sample.')
+              stop(sample, " is not a valid sample.")
             }
 
             SMPL <- sample

--- a/R/visualize.R
+++ b/R/visualize.R
@@ -33,7 +33,8 @@ setMethod("histogram",
               geom_histogram(binwidth = binwidth) +
               coord_trans(y = "sqrt") +
               scale_x_sqrt(breaks = c(1, 10, 50, 100, 250, 500, 750)) +
-              scale_y_continuous(breaks = c(0, 1, 10, 50, 100, 250, 500, 750, 1000, 2000, 3000)) +
+              scale_y_continuous(breaks = c(0, 1, 10, 50, 100, 250, 500, 750,
+                                            1000, 2000, 3000)) +
               xlab("#reads on head-to-tail splice junction") +
               ylab("#circRNAs") +
               theme(axis.title.y = element_text(size = 20),
@@ -86,13 +87,16 @@ setMethod("annotPie",
             }
 
 
-            collapse.to.other <- names(table(rowRanges(se)$feature)[table(rowRanges(se)$feature) < thresh])
+            collapse.to.other <-
+              names(table(rowRanges(se)$feature)[table(rowRanges(se)$feature)
+                                                 < thresh])
 
             tbl <- table(rowRanges(se)$feature)
             tmpdf <- data.table(feature = rep(names(tbl), tbl))
             tmpdf$feature[tmpdf$feature %in% collapse.to.other] <- "other"
 
-            nms <- names(table(tmpdf$feature))[order(table(tmpdf$feature), decreasing = T)]
+            nms <- names(table(tmpdf$feature))[order(table(tmpdf$feature),
+                                                     decreasing = T)]
             if ("other" %in% nms) nms <- c(nms[nms != "other"], "other")
 
             tmpdf$feature <- factor(tmpdf$feature, levels = nms)
@@ -116,7 +120,10 @@ setMethod("annotPie",
               coord_polar(theta = "y")
 
             if (nlevels(tmpdf$feature) <= 9) {
-              pie <- pie + scale_fill_manual(values = rev(brewer.pal(name = "Blues", n = nlevels(tmpdf$feature))))
+              pie <- pie +
+                scale_fill_manual(values =
+                                    rev(brewer.pal(name = "Blues",
+                                                   n = nlevels(tmpdf$feature))))
             }
 
             return(pie)

--- a/inst/scripts/test_load_data.R
+++ b/inst/scripts/test_load_data.R
@@ -1,8 +1,8 @@
 #CIRI2
 annot.list <- loadAnnotation("inst/extdata/db/test.sqlite")
-cdata <- data.frame(sample=c("riboz", "RNaseR"),
-                    filename=c("inst/extdata/ciri_demo_hek/HEK_riborezo_CIRI_sites.txt",
-                               "inst/extdata/ciri_demo_hek/HEK_RNaseR_CIRI_sites.txt"))
+cdata <- data.frame(sample = c("riboz", "RNaseR"),
+                    filename = c("inst/extdata/ciri_demo_hek/HEK_riborezo_CIRI_sites.txt",
+                                 "inst/extdata/ciri_demo_hek/HEK_RNaseR_CIRI_sites.txt"))
 
 # colData <- cdata
 # keep.linear <- TRUE
@@ -18,10 +18,10 @@ circs.se <-  annotateCircs(se = circs.se, annot.list = annot.list, assembly = "h
 # find_circ2
 annot.list <- loadAnnotation("data/test.sqlite")
 
-cdata <- data.frame(sample=c("D0", "D2", "D4"),
-                    filename=c("inst/extdata/Sy5y_D0_sites.bed",
-                               "/data/circrna/Human/Sy5y_diff/D2/Sy5y_D2_sites.bed",
-                               "/data/circrna/Human/Sy5y_diff/D4/Sy5y_D4_sites.bed"))
+cdata <- data.frame(sample = c("D0", "D2", "D4"),
+                    filename = c("inst/extdata/Sy5y_D0_sites.bed",
+                                 "/data/circrna/Human/Sy5y_diff/D2/Sy5y_D2_sites.bed",
+                                 "/data/circrna/Human/Sy5y_diff/D4/Sy5y_D4_sites.bed"))
 
 circs.se <- summarizeCircs(colData = cdata, wobble = 1, keepCols = 1:19)
 
@@ -39,10 +39,10 @@ uniqReadsQC(circs.se, "all")
 #library(hash)
 #annot.list <- loadAnnotation("data/test.sqlite")
 annot.list <- loadAnnotation("inst/extdata/hsa_ens75_minimal.sqlite")
-cdata <- data.frame(sample=c("FC1", "FC2", "H1", "H2", "L1", "L2"),
-                    filename=dir("inst/extdata/", full.names=T)[grep("rep", dir("inst/extdata/"))])
-#se <- summarizeCircs(dir("inst/extdata/", full.names=T)[grep("rep", dir("inst/extdata/"))], wobble=1, colData = cdata)
-se <- summarizeCircs(colData = cdata, wobble=1)
+cdata <- data.frame(sample = c("FC1", "FC2", "H1", "H2", "L1", "L2"),
+                    filename = dir("inst/extdata/", full.names = T)[grep("rep", dir("inst/extdata/"))])
+#se <- summarizeCircs(dir("inst/extdata/", full.names = T)[grep("rep", dir("inst/extdata/"))], wobble = 1, colData = cdata)
+se <- summarizeCircs(colData = cdata, wobble = 1)
 se <- annotateCircs(se, annot.list, "mm9", fixCoordIndexing = TRUE)
 tab <- resTable(se)
 tab
@@ -61,20 +61,20 @@ annotPie(se)
 # find_circ2
 annot.list <- loadAnnotation("data/test.sqlite")
 #annot.list <- loadAnnotation("inst/extdata/hsa_ens75_minimal.sqlite")
-#cdata <- data.frame(sample=c("FC1"),
-#                    filename="../data/fc2/FrontalCortex_rep1_circ_splice_sites.bed")
-# cdata <- data.frame(sample=c("CB1", "CB2", "FC1", "FC2"),
-#                     filename=c("../data/fc2_full/Cerebellum/rep1/circ_splice_sites.bed",
+#cdata <- data.frame(sample = c("FC1"),
+#                    filename = "../data/fc2/FrontalCortex_rep1_circ_splice_sites.bed")
+# cdata <- data.frame(sample = c("CB1", "CB2", "FC1", "FC2"),
+#                     filename = c("../data/fc2_full/Cerebellum/rep1/circ_splice_sites.bed",
 #                                "../data/fc2_full/Cerebellum/rep2/circ_splice_sites.bed",
 #                                "../data/fc2_full/FrontalCortex/rep1/circ_splice_sites.bed",
 #                                "../data/fc2_full/FrontalCortex/rep2/circ_splice_sites.bed"))
-cdata <- data.frame(sample=c("CB1", "CB2", "FC1", "FC2"),
-                    filename=c("/data/rajewsky/home/pglazar/projects/ENCODE_brain/human/Cerebellum/rep1/circ_splice_sites.bed",
+cdata <- data.frame(sample = c("CB1", "CB2", "FC1", "FC2"),
+                    filename = c("/data/rajewsky/home/pglazar/projects/ENCODE_brain/human/Cerebellum/rep1/circ_splice_sites.bed",
                                "/data/rajewsky/home/pglazar/projects/ENCODE_brain/human/Cerebellum/rep2/circ_splice_sites.bed",
                                "/data/rajewsky/home/pglazar/projects/ENCODE_brain/human/FrontalCortex/rep1/circ_splice_sites.bed",
                                "/data/rajewsky/home/pglazar/projects/ENCODE_brain/human/FrontalCortex/rep2/circ_splice_sites.bed"))
-#se <- summarizeCircs(dir("inst/extdata/", full.names=T)[grep("rep", dir("inst/extdata/"))], wobble=1, colData = cdata)
-se <- summarizeCircs(colData = cdata, wobble=1)
+#se <- summarizeCircs(dir("inst/extdata/", full.names = T)[grep("rep", dir("inst/extdata/"))], wobble = 1, colData = cdata)
+se <- summarizeCircs(colData = cdata, wobble = 1)
 se <- annotateHostGenes(se, annot.list$genes)
 resTable(se)
 se <- annotateFlanks(se, annot.list$gene.feats)
@@ -86,15 +86,15 @@ resTable(se)
 histogram(se)
 annotPie(se)
 
-se2 <- summarizeCircs(colData = cdata, wobble=1)
+se2 <- summarizeCircs(colData = cdata, wobble = 1)
 se2 <- annotateCircs(se2, annot.list, "hg19")
 histogram(se2)
 annotPie(se2, other.threshold = 0.02)
 
 # SH-SY5Y test
-cdata <- data.frame(sample=c("D0"),
-                    filename="data/Sy5y_D0_sites.bed")
-se <- summarizeCircs(as.character(cdata$filename), wobble=1, colData = cdata)
+cdata <- data.frame(sample = c("D0"),
+                    filename = "data/Sy5y_D0_sites.bed")
+se <- summarizeCircs(as.character(cdata$filename), wobble = 1, colData = cdata)
 se <- annotateHostGenes(se, annot.list$genes)
 se <- annotateFlanks(se, annot.list$gene.feats)
 se <- annotateJunctions(se, annot.list$junctions)
@@ -105,14 +105,14 @@ annotPie(se, 0.1)
 
 
 # wrapper
-cdata <- data.frame(sample=c("FC1", "FC2", "H1", "H2", "L1", "L2"),
-                    filename=dir("data/demo/", full.names=T))
-se  <- summarizeCircs(circ.files = as.character(cdata$filename), wobble=1, colData = cdata)
-se1 <- annotateCircs(se, annot.list=annot.list)
-cdata <- data.frame(sample=c("D0"),
-                    filename="data/Sy5y_D0_sites.bed")
-se  <- summarizeCircs(circ.files = as.character(cdata$filename), wobble=1, colData = cdata)
-se2 <- annotateCircs(se = se, annot.list=annot.list, fixCoordIndexing = TRUE)
+cdata <- data.frame(sample = c("FC1", "FC2", "H1", "H2", "L1", "L2"),
+                    filename = dir("data/demo/", full.names = T))
+se  <- summarizeCircs(circ.files = as.character(cdata$filename), wobble = 1, colData = cdata)
+se1 <- annotateCircs(se, annot.list = annot.list)
+cdata <- data.frame(sample = c("D0"),
+                    filename = "data/Sy5y_D0_sites.bed")
+se  <- summarizeCircs(circ.files = as.character(cdata$filename), wobble = 1, colData = cdata)
+se2 <- annotateCircs(se = se, annot.list = annot.list, fixCoordIndexing = TRUE)
 
 # connect to the public instance of circBase
 con <- dbConnect(drv    = dbDriver("MySQL"),
@@ -126,26 +126,26 @@ con <- dbConnect(drv    = dbDriver("MySQL"),
 ah <- AnnotationHub()
 gtf.gr <- ah[[getOption("assembly2annhub")[["hg19"]]]]
 gtf.gr <- keepStandardChromosomes(gtf.gr)
-seqlevels(gtf.gr) <- paste("chr", seqlevels(gtf.gr), sep="")
+seqlevels(gtf.gr) <- paste("chr", seqlevels(gtf.gr), sep = "")
 seqlevels(gtf.gr)[which(seqlevels(gtf.gr) == "chrMT")] <- "chrM"
 gtf.gr <- subsetByOverlaps(gtf.gr, rowRanges(se))
-txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE, metadata = data.frame(name="Genome", value="GRCh37"))
-saveDb(txdb, file="../data/hsa_ens75_minimal.gtf")
+txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE, metadata = data.frame(name = "Genome", value = "GRCh37"))
+saveDb(txdb, file = "../data/hsa_ens75_minimal.gtf")
 
 
 circ.ends.gr <- rowRanges(se)
 start(circ.ends.gr) <- end(circ.ends.gr)
 
-AnnotateRanges(r1 = circ.ends.gr,         l = annot.list$gene.feats,  null.fact = "intergenic", type="precedence")[1547]
-AnnotateRanges(r1 = circ.ends.gr[1547],   l = annot.list$gene.feats,  null.fact = "intergenic", type="precedence")
+AnnotateRanges(r1 = circ.ends.gr,         l = annot.list$gene.feats,  null.fact = "intergenic", type = "precedence")[1547]
+AnnotateRanges(r1 = circ.ends.gr[1547],   l = annot.list$gene.feats,  null.fact = "intergenic", type = "precedence")
 
 
 
-circs <- lapply(dir("data/demo/", full.names=T)[grep("sites", dir("data/demo/"))], readCircs)
-circs <- lapply(circs, circLinRatio, return.readcounts=TRUE)
+circs <- lapply(dir("data/demo/", full.names = T)[grep("sites", dir("data/demo/"))], readCircs)
+circs <- lapply(circs, circLinRatio, return.readcounts = TRUE)
 
 
-circ.files <- dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/", full.names=T)[grep("sites", dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/"))]
+circ.files <- dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/", full.names = T)[grep("sites", dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/"))]
 keep.linear = TRUE
 wobble = 1
 subs = "all"

--- a/inst/scripts/test_load_data.R
+++ b/inst/scripts/test_load_data.R
@@ -1,8 +1,9 @@
 #CIRI2
 annot.list <- loadAnnotation("inst/extdata/db/test.sqlite")
 cdata <- data.frame(sample = c("riboz", "RNaseR"),
-                    filename = c("inst/extdata/ciri_demo_hek/HEK_riborezo_CIRI_sites.txt",
-                                 "inst/extdata/ciri_demo_hek/HEK_RNaseR_CIRI_sites.txt"))
+                    filename = paste0("inst/extdata/ciri_demo_hek/",
+                                      c("HEK_riborezo_CIRI_sites.txt",
+                                        "HEK_RNaseR_CIRI_sites.txt")))
 
 # colData <- cdata
 # keep.linear <- TRUE
@@ -12,20 +13,24 @@ cdata <- data.frame(sample = c("riboz", "RNaseR"),
 # keepCols <- 1:12
 
 
-circs.se <- summarizeCircs(colData = cdata, keep.linear = FALSE, wobble = 1, subs = "all", qualfilter = FALSE, keepCols = 1:12)
-circs.se <-  annotateCircs(se = circs.se, annot.list = annot.list, assembly = "hg19")
+circs.se <- summarizeCircs(colData = cdata, keep.linear = FALSE, wobble = 1,
+                           subs = "all", qualfilter = FALSE, keepCols = 1:12)
+circs.se <-  annotateCircs(se = circs.se, annot.list = annot.list,
+                           assembly = "hg19")
 
 # find_circ2
 annot.list <- loadAnnotation("data/test.sqlite")
 
 cdata <- data.frame(sample = c("D0", "D2", "D4"),
                     filename = c("inst/extdata/Sy5y_D0_sites.bed",
-                                 "/data/circrna/Human/Sy5y_diff/D2/Sy5y_D2_sites.bed",
-                                 "/data/circrna/Human/Sy5y_diff/D4/Sy5y_D4_sites.bed"))
+                                 paste0("/data/circrna/Human/Sy5y_diff/",
+                                        c("D2/Sy5y_D2_sites.bed",
+                                          "D4/Sy5y_D4_sites.bed"))))
 
 circs.se <- summarizeCircs(colData = cdata, wobble = 1, keepCols = 1:19)
 
-circs.se <- annotateCircs(se = circs.se, annot.list = annot.list, assembly = "hg19", fixCoordIndexing = T)
+circs.se <- annotateCircs(se = circs.se, annot.list = annot.list,
+                          assembly = "hg19", fixCoordIndexing = T)
 
 
 
@@ -40,8 +45,12 @@ uniqReadsQC(circs.se, "all")
 #annot.list <- loadAnnotation("data/test.sqlite")
 annot.list <- loadAnnotation("inst/extdata/hsa_ens75_minimal.sqlite")
 cdata <- data.frame(sample = c("FC1", "FC2", "H1", "H2", "L1", "L2"),
-                    filename = dir("inst/extdata/", full.names = T)[grep("rep", dir("inst/extdata/"))])
-#se <- summarizeCircs(dir("inst/extdata/", full.names = T)[grep("rep", dir("inst/extdata/"))], wobble = 1, colData = cdata)
+                    filename = dir("inst/extdata/",
+                                   full.names = T)[grep("rep",
+                                                        dir("inst/extdata/"))])
+#se <- summarizeCircs(dir("inst/extdata/",
+#                         full.names = T)[grep("rep", dir("inst/extdata/"))],
+#                     wobble = 1, colData = cdata)
 se <- summarizeCircs(colData = cdata, wobble = 1)
 se <- annotateCircs(se, annot.list, "mm9", fixCoordIndexing = TRUE)
 tab <- resTable(se)
@@ -61,19 +70,19 @@ annotPie(se)
 # find_circ2
 annot.list <- loadAnnotation("data/test.sqlite")
 #annot.list <- loadAnnotation("inst/extdata/hsa_ens75_minimal.sqlite")
-#cdata <- data.frame(sample = c("FC1"),
-#                    filename = "../data/fc2/FrontalCortex_rep1_circ_splice_sites.bed")
-# cdata <- data.frame(sample = c("CB1", "CB2", "FC1", "FC2"),
-#                     filename = c("../data/fc2_full/Cerebellum/rep1/circ_splice_sites.bed",
-#                                "../data/fc2_full/Cerebellum/rep2/circ_splice_sites.bed",
-#                                "../data/fc2_full/FrontalCortex/rep1/circ_splice_sites.bed",
-#                                "../data/fc2_full/FrontalCortex/rep2/circ_splice_sites.bed"))
+#cdata <-
+#  data.frame(sample = c("FC1"),
+#             filename = "../data/fc2/FrontalCortex_rep1_circ_splice_sites.bed")
 cdata <- data.frame(sample = c("CB1", "CB2", "FC1", "FC2"),
-                    filename = c("/data/rajewsky/home/pglazar/projects/ENCODE_brain/human/Cerebellum/rep1/circ_splice_sites.bed",
-                               "/data/rajewsky/home/pglazar/projects/ENCODE_brain/human/Cerebellum/rep2/circ_splice_sites.bed",
-                               "/data/rajewsky/home/pglazar/projects/ENCODE_brain/human/FrontalCortex/rep1/circ_splice_sites.bed",
-                               "/data/rajewsky/home/pglazar/projects/ENCODE_brain/human/FrontalCortex/rep2/circ_splice_sites.bed"))
-#se <- summarizeCircs(dir("inst/extdata/", full.names = T)[grep("rep", dir("inst/extdata/"))], wobble = 1, colData = cdata)
+                    filename = paste0("/data/rajewsky/home/pglazar/projects/",
+                                      "ENCODE_brain/human/",
+#                    filename = paste0("../data/fc2_full/",
+                                      c(paste0(   "Cerebellum/rep", 1:2),
+                                        paste0("FrontalCortex/rep", 1:2)),
+                                      "/circ_splice_sites.bed"))
+#se <- summarizeCircs(dir("inst/extdata/",
+#                         full.names = T)[grep("rep", dir("inst/extdata/"))],
+#                     wobble = 1, colData = cdata)
 se <- summarizeCircs(colData = cdata, wobble = 1)
 se <- annotateHostGenes(se, annot.list$genes)
 resTable(se)
@@ -107,11 +116,13 @@ annotPie(se, 0.1)
 # wrapper
 cdata <- data.frame(sample = c("FC1", "FC2", "H1", "H2", "L1", "L2"),
                     filename = dir("data/demo/", full.names = T))
-se  <- summarizeCircs(circ.files = as.character(cdata$filename), wobble = 1, colData = cdata)
+se  <- summarizeCircs(circ.files = as.character(cdata$filename), wobble = 1,
+                      colData = cdata)
 se1 <- annotateCircs(se, annot.list = annot.list)
 cdata <- data.frame(sample = c("D0"),
                     filename = "data/Sy5y_D0_sites.bed")
-se  <- summarizeCircs(circ.files = as.character(cdata$filename), wobble = 1, colData = cdata)
+se  <- summarizeCircs(circ.files = as.character(cdata$filename), wobble = 1,
+                      colData = cdata)
 se2 <- annotateCircs(se = se, annot.list = annot.list, fixCoordIndexing = TRUE)
 
 # connect to the public instance of circBase
@@ -129,23 +140,32 @@ gtf.gr <- keepStandardChromosomes(gtf.gr)
 seqlevels(gtf.gr) <- paste("chr", seqlevels(gtf.gr), sep = "")
 seqlevels(gtf.gr)[which(seqlevels(gtf.gr) == "chrMT")] <- "chrM"
 gtf.gr <- subsetByOverlaps(gtf.gr, rowRanges(se))
-txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE, metadata = data.frame(name = "Genome", value = "GRCh37"))
+txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE,
+                            metadata = data.frame(name = "Genome",
+                                                  value = "GRCh37"))
 saveDb(txdb, file = "../data/hsa_ens75_minimal.gtf")
 
 
 circ.ends.gr <- rowRanges(se)
 start(circ.ends.gr) <- end(circ.ends.gr)
 
-AnnotateRanges(r1 = circ.ends.gr,         l = annot.list$gene.feats,  null.fact = "intergenic", type = "precedence")[1547]
-AnnotateRanges(r1 = circ.ends.gr[1547],   l = annot.list$gene.feats,  null.fact = "intergenic", type = "precedence")
+AnnotateRanges(r1 = circ.ends.gr,       l = annot.list$gene.feats,
+               null.fact = "intergenic", type = "precedence")[1547]
+AnnotateRanges(r1 = circ.ends.gr[1547], l = annot.list$gene.feats,
+               null.fact = "intergenic", type = "precedence")
 
 
 
-circs <- lapply(dir("data/demo/", full.names = T)[grep("sites", dir("data/demo/"))], readCircs)
+circs <- lapply(dir("data/demo/", full.names = T)[grep("sites",
+                                                       dir("data/demo/"))],
+                readCircs)
 circs <- lapply(circs, circLinRatio, return.readcounts = TRUE)
 
 
-circ.files <- dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/", full.names <- T)[grep("sites", dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/"))]
+circ.files <- dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/",
+                  full.names <- T)[grep("sites",
+                                   dir(paste0("/clusterhome/pglazar/projects/",
+                                              "circus/ciRcus/data/demo/")))]
 keep.linear <- TRUE
 wobble <- 1
 subs <- "all"

--- a/inst/scripts/test_load_data.R
+++ b/inst/scripts/test_load_data.R
@@ -145,10 +145,10 @@ circs <- lapply(dir("data/demo/", full.names = T)[grep("sites", dir("data/demo/"
 circs <- lapply(circs, circLinRatio, return.readcounts = TRUE)
 
 
-circ.files <- dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/", full.names = T)[grep("sites", dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/"))]
-keep.linear = TRUE
-wobble = 1
-subs = "all"
-qualfilter = TRUE
-keepCols = 1:6
-colData = NULL
+circ.files <- dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/", full.names <- T)[grep("sites", dir("/clusterhome/pglazar/projects/circus/ciRcus/data/demo/"))]
+keep.linear <- TRUE
+wobble <- 1
+subs <- "all"
+qualfilter <- TRUE
+keepCols <- 1:6
+colData <- NULL

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -1,0 +1,7 @@
+# taken from https://github.com/jimhester/lintr#testthat
+if (requireNamespace("lintr", quietly = TRUE)) {
+  context("lints")
+  test_that("Package Style", {
+    lintr::expect_lint_free()
+  })
+}

--- a/tests/testthat/test-loadAnnot.R
+++ b/tests/testthat/test-loadAnnot.R
@@ -69,14 +69,14 @@ test_that("sample labels are robust upon resorting colData", {
   expect_equal(rownames(colData(se.unsorted)), colData(se.unsorted)$sample)
 
   # sorted vs. sorted
-  expect_equal(unname(assays(se.sorted)$circ[, "FrontalCortex_rep1_sites.bed"]),   resTable(se.sorted)$FrontalCortex_rep1_sites.bed_circ)
+  expect_equal(unname(assays(se.sorted)$circ[, "FrontalCortex_rep1_sites.bed"]),   resTable(se.sorted)[["FrontalCortex_rep1_sites.bed_circ"]])
   # unsorted vs. unsorted
-  expect_equal(unname(assays(se.unsorted)$circ[, "FrontalCortex_rep1_sites.bed"]), resTable(se.unsorted)$FrontalCortex_rep1_sites.bed_circ)
+  expect_equal(unname(assays(se.unsorted)$circ[, "FrontalCortex_rep1_sites.bed"]), resTable(se.unsorted)[["FrontalCortex_rep1_sites.bed_circ"]])
 
   # sorted vs. unsorted, assays()
   expect_equal(assays(se.sorted)$circ[, "FrontalCortex_rep1_sites.bed"],   assays(se.unsorted)$circ[, "FrontalCortex_rep1_sites.bed"])
   # sorted vs. unsorted, resTable()
-  expect_equal(resTable(se.sorted)$FrontalCortex_rep1_sites.bed_circ, resTable(se.unsorted)$FrontalCortex_rep1_sites.bed_circ)
+  expect_equal(resTable(se.sorted)[, "FrontalCortex_rep1_sites.bed_circ"], resTable(se.unsorted)[, "FrontalCortex_rep1_sites.bed_circ"])
 })
 
 test_that("CIRI2 input can be digested by ciRcus", {

--- a/tests/testthat/test-loadAnnot.R
+++ b/tests/testthat/test-loadAnnot.R
@@ -1,7 +1,8 @@
 test_that("summarizeCircs", {
 
 
-  circ.files <- list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
+  circ.files <- list.files(system.file("extdata/encode_demo_small",
+                                       package = "ciRcus"),
                            pattern = "sites.bed",
                            full.names = TRUE)
   circ.files <- circ.files[!grepl("Sy5y", circ.files)]
@@ -15,7 +16,8 @@ test_that("summarizeCircs", {
   expect_equal(sum(assays(se)$circ[, 1]),  1574)
   # circ read counts
   expect_equal(assays(se)$circ[[3, 3]],     14892)
-  expect_equal(unname(colSums(assays(se)$circ)), c(1574, 757, 17266, 7221, 67, 93))
+  expect_equal(unname(colSums(assays(se)$circ)),
+               c(1574, 757, 17266, 7221, 67, 93))
   # lin read counts
   expect_equal(assays(se)$linear.start[[3, 3]], 2362)
   # lin read count for a non-existing circRNA
@@ -30,7 +32,8 @@ test_that("summarizeCircs", {
 
 test_that("Annotation", {
 
-  circ.files <- list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
+  circ.files <- list.files(system.file("extdata/encode_demo_small",
+                                       package = "ciRcus"),
                            pattern = "sites.bed",
                            full.names = TRUE)
   circ.files <- circ.files[!grepl("Sy5y", circ.files)]
@@ -38,7 +41,8 @@ test_that("Annotation", {
 
 
   # annotation tests
-  annot.file <- system.file("extdata/db/hsa_ens75_minimal.sqlite", package = "ciRcus")
+  annot.file <- system.file("extdata/db/hsa_ens75_minimal.sqlite",
+                            package = "ciRcus")
   annot.list <- suppressMessages(loadAnnotation(annot.file))
   se <- annotateHostGenes(se, annot.list$genes)
   expect_equal(resTable(se)$gene_id, c("ENSG00000183023",
@@ -56,7 +60,8 @@ test_that("Annotation", {
 
 test_that("sample labels are robust upon resorting colData", {
 
-  circ.files <- list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
+  circ.files <- list.files(system.file("extdata/encode_demo_small",
+                                       package = "ciRcus"),
                            pattern = "sites.bed",
                            full.names = TRUE)
   circ.files <- circ.files[!grepl("Sy5y", circ.files)]
@@ -69,23 +74,30 @@ test_that("sample labels are robust upon resorting colData", {
   expect_equal(rownames(colData(se.unsorted)), colData(se.unsorted)$sample)
 
   # sorted vs. sorted
-  expect_equal(unname(assays(se.sorted)$circ[, "FrontalCortex_rep1_sites.bed"]),   resTable(se.sorted)[["FrontalCortex_rep1_sites.bed_circ"]])
+  expect_equal(unname(assays(se.sorted)$circ[, "FrontalCortex_rep1_sites.bed"]),
+               resTable(se.sorted)[["FrontalCortex_rep1_sites.bed_circ"]])
   # unsorted vs. unsorted
-  expect_equal(unname(assays(se.unsorted)$circ[, "FrontalCortex_rep1_sites.bed"]), resTable(se.unsorted)[["FrontalCortex_rep1_sites.bed_circ"]])
+  expect_equal(unname(assays(se.unsorted)$circ[,
+                                               "FrontalCortex_rep1_sites.bed"]),
+               resTable(se.unsorted)[["FrontalCortex_rep1_sites.bed_circ"]])
 
   # sorted vs. unsorted, assays()
-  expect_equal(assays(se.sorted)$circ[, "FrontalCortex_rep1_sites.bed"],   assays(se.unsorted)$circ[, "FrontalCortex_rep1_sites.bed"])
+  expect_equal(assays(se.sorted)$circ[, "FrontalCortex_rep1_sites.bed"],
+               assays(se.unsorted)$circ[, "FrontalCortex_rep1_sites.bed"])
   # sorted vs. unsorted, resTable()
-  expect_equal(resTable(se.sorted)[, "FrontalCortex_rep1_sites.bed_circ"], resTable(se.unsorted)[, "FrontalCortex_rep1_sites.bed_circ"])
+  expect_equal(resTable(se.sorted)[, "FrontalCortex_rep1_sites.bed_circ"],
+               resTable(se.unsorted)[, "FrontalCortex_rep1_sites.bed_circ"])
 })
 
 test_that("CIRI2 input can be digested by ciRcus", {
 
-  circ.files <- list.files(system.file("extdata/ciri_demo_hek", package = "ciRcus"),
+  circ.files <- list.files(system.file("extdata/ciri_demo_hek",
+                                       package = "ciRcus"),
                            pattern = "HEK",
                            full.names = TRUE)
 
-  se <- summarizeCircs(circ.files, keep.linear = FALSE, wobble = 1, subs = "all", qualfilter = FALSE, keepCols = 1:12)
+  se <- summarizeCircs(circ.files, keep.linear = FALSE, wobble = 1,
+                       subs = "all", qualfilter = FALSE, keepCols = 1:12)
 
   # total circRNAs in both samples
   expect_equal(nrow(resTable(se)), 14936)

--- a/tests/testthat/test-loadAnnot.R
+++ b/tests/testthat/test-loadAnnot.R
@@ -30,15 +30,15 @@ test_that("summarizeCircs", {
 
 test_that('Annotation',{
 
-  circ.files = list.files(system.file('extdata/encode_demo_small', package='ciRcus'),
-                          pattern='sites.bed',
-                          full.names=TRUE)
+  circ.files = list.files(system.file('extdata/encode_demo_small', package = 'ciRcus'),
+                          pattern = 'sites.bed',
+                          full.names = TRUE)
   circ.files = circ.files[!grepl('Sy5y', circ.files)]
-  se <- summarizeCircs(circ.files, wobble=1, keepCols = 1:7)
+  se <- summarizeCircs(circ.files, wobble = 1, keepCols = 1:7)
 
 
   # annotation tests
-  annot.file = system.file('extdata/db/hsa_ens75_minimal.sqlite', package='ciRcus')
+  annot.file = system.file('extdata/db/hsa_ens75_minimal.sqlite', package = 'ciRcus')
   annot.list <- suppressMessages(loadAnnotation(annot.file))
   se <- annotateHostGenes(se, annot.list$genes)
   expect_equal(resTable(se)$gene_id, c("ENSG00000183023",
@@ -56,9 +56,9 @@ test_that('Annotation',{
 
 test_that('sample labels are robust upon resorting colData', {
 
-  circ.files = list.files(system.file('extdata/encode_demo_small', package='ciRcus'),
-                          pattern='sites.bed',
-                          full.names=TRUE)
+  circ.files = list.files(system.file('extdata/encode_demo_small', package = 'ciRcus'),
+                          pattern = 'sites.bed',
+                          full.names = TRUE)
   circ.files = circ.files[!grepl('Sy5y', circ.files)]
 
   se.sorted   <- summarizeCircs(circ.files,      wobble = 1, keepCols = 1:7)
@@ -81,16 +81,16 @@ test_that('sample labels are robust upon resorting colData', {
 
 test_that('CIRI2 input can be digested by ciRcus', {
 
-  circ.files = list.files(system.file('extdata/ciri_demo_hek', package='ciRcus'),
-                          pattern='HEK',
-                          full.names=TRUE)
+  circ.files = list.files(system.file('extdata/ciri_demo_hek', package = 'ciRcus'),
+                          pattern = 'HEK',
+                          full.names = TRUE)
 
   se <- summarizeCircs(circ.files, keep.linear = FALSE, wobble = 1, subs = "all", qualfilter = FALSE, keepCols = 1:12)
 
   # total circRNAs in both samples
   expect_equal(nrow(resTable(se)), 14936)
   # there should be 4127 ribozero circRNAs
-  expect_equal(sum(resTable(se)[, 6, with=F] > 0), 4127)
+  expect_equal(sum(resTable(se)[, 6, with = F] > 0), 4127)
   # there should be 14013 RNaseR circRNAs
-  expect_equal(sum(resTable(se)[, 7, with=F] > 0), 14013)
+  expect_equal(sum(resTable(se)[, 7, with = F] > 0), 14013)
 })

--- a/tests/testthat/test-loadAnnot.R
+++ b/tests/testthat/test-loadAnnot.R
@@ -2,8 +2,8 @@ test_that("summarizeCircs", {
 
 
   circ.files <- list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
-                          pattern = "sites.bed",
-                          full.names = TRUE)
+                           pattern = "sites.bed",
+                           full.names = TRUE)
   circ.files <- circ.files[!grepl("Sy5y", circ.files)]
   se <- summarizeCircs(circ.files, wobble = 1, keepCols = 1:7)
 
@@ -30,15 +30,15 @@ test_that("summarizeCircs", {
 
 test_that("Annotation", {
 
-  circ.files = list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
-                          pattern = "sites.bed",
-                          full.names = TRUE)
-  circ.files = circ.files[!grepl("Sy5y", circ.files)]
+  circ.files <- list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
+                           pattern = "sites.bed",
+                           full.names = TRUE)
+  circ.files <- circ.files[!grepl("Sy5y", circ.files)]
   se <- summarizeCircs(circ.files, wobble = 1, keepCols = 1:7)
 
 
   # annotation tests
-  annot.file = system.file("extdata/db/hsa_ens75_minimal.sqlite", package = "ciRcus")
+  annot.file <- system.file("extdata/db/hsa_ens75_minimal.sqlite", package = "ciRcus")
   annot.list <- suppressMessages(loadAnnotation(annot.file))
   se <- annotateHostGenes(se, annot.list$genes)
   expect_equal(resTable(se)$gene_id, c("ENSG00000183023",
@@ -56,10 +56,10 @@ test_that("Annotation", {
 
 test_that("sample labels are robust upon resorting colData", {
 
-  circ.files = list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
-                          pattern = "sites.bed",
-                          full.names = TRUE)
-  circ.files = circ.files[!grepl("Sy5y", circ.files)]
+  circ.files <- list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
+                           pattern = "sites.bed",
+                           full.names = TRUE)
+  circ.files <- circ.files[!grepl("Sy5y", circ.files)]
 
   se.sorted   <- summarizeCircs(circ.files,      wobble = 1, keepCols = 1:7)
   se.unsorted <- summarizeCircs(rev(circ.files), wobble = 1, keepCols = 1:7)
@@ -81,9 +81,9 @@ test_that("sample labels are robust upon resorting colData", {
 
 test_that("CIRI2 input can be digested by ciRcus", {
 
-  circ.files = list.files(system.file("extdata/ciri_demo_hek", package = "ciRcus"),
-                          pattern = "HEK",
-                          full.names = TRUE)
+  circ.files <- list.files(system.file("extdata/ciri_demo_hek", package = "ciRcus"),
+                           pattern = "HEK",
+                           full.names = TRUE)
 
   se <- summarizeCircs(circ.files, keep.linear = FALSE, wobble = 1, subs = "all", qualfilter = FALSE, keepCols = 1:12)
 

--- a/tests/testthat/test-loadAnnot.R
+++ b/tests/testthat/test-loadAnnot.R
@@ -1,10 +1,10 @@
 test_that("summarizeCircs", {
 
 
-  circ.files <- list.files(system.file('extdata/encode_demo_small', package = 'ciRcus'),
-                          pattern = 'sites.bed',
+  circ.files <- list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
+                          pattern = "sites.bed",
                           full.names = TRUE)
-  circ.files <- circ.files[!grepl('Sy5y', circ.files)]
+  circ.files <- circ.files[!grepl("Sy5y", circ.files)]
   se <- summarizeCircs(circ.files, wobble = 1, keepCols = 1:7)
 
   # score matrix should be 4 by 6 (4 circs, 6 samples)
@@ -28,17 +28,17 @@ test_that("summarizeCircs", {
 })
 
 
-test_that('Annotation',{
+test_that("Annotation",{
 
-  circ.files = list.files(system.file('extdata/encode_demo_small', package = 'ciRcus'),
-                          pattern = 'sites.bed',
+  circ.files = list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
+                          pattern = "sites.bed",
                           full.names = TRUE)
-  circ.files = circ.files[!grepl('Sy5y', circ.files)]
+  circ.files = circ.files[!grepl("Sy5y", circ.files)]
   se <- summarizeCircs(circ.files, wobble = 1, keepCols = 1:7)
 
 
   # annotation tests
-  annot.file = system.file('extdata/db/hsa_ens75_minimal.sqlite', package = 'ciRcus')
+  annot.file = system.file("extdata/db/hsa_ens75_minimal.sqlite", package = "ciRcus")
   annot.list <- suppressMessages(loadAnnotation(annot.file))
   se <- annotateHostGenes(se, annot.list$genes)
   expect_equal(resTable(se)$gene_id, c("ENSG00000183023",
@@ -54,12 +54,12 @@ test_that('Annotation',{
   expect_equal(unname(assays(se)$ratio[3,4]), 4.03)
 })
 
-test_that('sample labels are robust upon resorting colData', {
+test_that("sample labels are robust upon resorting colData", {
 
-  circ.files = list.files(system.file('extdata/encode_demo_small', package = 'ciRcus'),
-                          pattern = 'sites.bed',
+  circ.files = list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
+                          pattern = "sites.bed",
                           full.names = TRUE)
-  circ.files = circ.files[!grepl('Sy5y', circ.files)]
+  circ.files = circ.files[!grepl("Sy5y", circ.files)]
 
   se.sorted   <- summarizeCircs(circ.files,      wobble = 1, keepCols = 1:7)
   se.unsorted <- summarizeCircs(rev(circ.files), wobble = 1, keepCols = 1:7)
@@ -69,20 +69,20 @@ test_that('sample labels are robust upon resorting colData', {
   expect_equal(rownames(colData(se.unsorted)), colData(se.unsorted)$sample)
 
   # sorted vs. sorted
-  expect_equal(unname(assays(se.sorted)$circ[,'FrontalCortex_rep1_sites.bed']),   resTable(se.sorted)$FrontalCortex_rep1_sites.bed_circ)
+  expect_equal(unname(assays(se.sorted)$circ[,"FrontalCortex_rep1_sites.bed"]),   resTable(se.sorted)$FrontalCortex_rep1_sites.bed_circ)
   # unsorted vs. unsorted
-  expect_equal(unname(assays(se.unsorted)$circ[,'FrontalCortex_rep1_sites.bed']), resTable(se.unsorted)$FrontalCortex_rep1_sites.bed_circ)
+  expect_equal(unname(assays(se.unsorted)$circ[,"FrontalCortex_rep1_sites.bed"]), resTable(se.unsorted)$FrontalCortex_rep1_sites.bed_circ)
 
   # sorted vs. unsorted, assays()
-  expect_equal(assays(se.sorted)$circ[,'FrontalCortex_rep1_sites.bed'],   assays(se.unsorted)$circ[,'FrontalCortex_rep1_sites.bed'])
+  expect_equal(assays(se.sorted)$circ[,"FrontalCortex_rep1_sites.bed"],   assays(se.unsorted)$circ[,"FrontalCortex_rep1_sites.bed"])
   # sorted vs. unsorted, resTable()
   expect_equal(resTable(se.sorted)$FrontalCortex_rep1_sites.bed_circ, resTable(se.unsorted)$FrontalCortex_rep1_sites.bed_circ)
 })
 
-test_that('CIRI2 input can be digested by ciRcus', {
+test_that("CIRI2 input can be digested by ciRcus", {
 
-  circ.files = list.files(system.file('extdata/ciri_demo_hek', package = 'ciRcus'),
-                          pattern = 'HEK',
+  circ.files = list.files(system.file("extdata/ciri_demo_hek", package = "ciRcus"),
+                          pattern = "HEK",
                           full.names = TRUE)
 
   se <- summarizeCircs(circ.files, keep.linear = FALSE, wobble = 1, subs = "all", qualfilter = FALSE, keepCols = 1:12)

--- a/tests/testthat/test-loadAnnot.R
+++ b/tests/testthat/test-loadAnnot.R
@@ -8,18 +8,18 @@ test_that("summarizeCircs", {
   se <- summarizeCircs(circ.files, wobble = 1, keepCols = 1:7)
 
   # score matrix should be 4 by 6 (4 circs, 6 samples)
-  expect_equal(dim(assays(se)$circ),     c(4,6))
+  expect_equal(dim(assays(se)$circ),     c(4, 6))
   # there should be 4 assays
   expect_equal(length(assays(se)), 4)
   # the total number of circRNA reads in FrontalCortex rep1 should be 1574
-  expect_equal(sum(assays(se)$circ[,1]),  1574)
+  expect_equal(sum(assays(se)$circ[, 1]),  1574)
   # circ read counts
-  expect_equal(assays(se)$circ[[3,3]],     14892)
+  expect_equal(assays(se)$circ[[3, 3]],     14892)
   expect_equal(unname(colSums(assays(se)$circ)), c(1574, 757, 17266, 7221, 67, 93))
   # lin read counts
-  expect_equal(assays(se)$linear.start[[3,3]], 2362)
+  expect_equal(assays(se)$linear.start[[3, 3]], 2362)
   # lin read count for a non-existing circRNA
-  expect_equal(assays(se)$linear.end[[2,1]], 90)
+  expect_equal(assays(se)$linear.end[[2, 1]], 90)
   # circular unique read counts
   expect_equal(unname(rowSums(assays(se)$circ.uniq)), c(1105, 40, 4866, 218))
   # resTable tests
@@ -28,7 +28,7 @@ test_that("summarizeCircs", {
 })
 
 
-test_that("Annotation",{
+test_that("Annotation", {
 
   circ.files = list.files(system.file("extdata/encode_demo_small", package = "ciRcus"),
                           pattern = "sites.bed",
@@ -51,7 +51,7 @@ test_that("Annotation",{
   se <- annotateJunctions(se, annot.list$junctions)
   expect_equal(resTable(se)$junct.known, c("5pr", "5pr", "5pr", "both"))
   se <- circLinRatio(se)
-  expect_equal(unname(assays(se)$ratio[3,4]), 4.03)
+  expect_equal(unname(assays(se)$ratio[3, 4]), 4.03)
 })
 
 test_that("sample labels are robust upon resorting colData", {
@@ -69,12 +69,12 @@ test_that("sample labels are robust upon resorting colData", {
   expect_equal(rownames(colData(se.unsorted)), colData(se.unsorted)$sample)
 
   # sorted vs. sorted
-  expect_equal(unname(assays(se.sorted)$circ[,"FrontalCortex_rep1_sites.bed"]),   resTable(se.sorted)$FrontalCortex_rep1_sites.bed_circ)
+  expect_equal(unname(assays(se.sorted)$circ[, "FrontalCortex_rep1_sites.bed"]),   resTable(se.sorted)$FrontalCortex_rep1_sites.bed_circ)
   # unsorted vs. unsorted
-  expect_equal(unname(assays(se.unsorted)$circ[,"FrontalCortex_rep1_sites.bed"]), resTable(se.unsorted)$FrontalCortex_rep1_sites.bed_circ)
+  expect_equal(unname(assays(se.unsorted)$circ[, "FrontalCortex_rep1_sites.bed"]), resTable(se.unsorted)$FrontalCortex_rep1_sites.bed_circ)
 
   # sorted vs. unsorted, assays()
-  expect_equal(assays(se.sorted)$circ[,"FrontalCortex_rep1_sites.bed"],   assays(se.unsorted)$circ[,"FrontalCortex_rep1_sites.bed"])
+  expect_equal(assays(se.sorted)$circ[, "FrontalCortex_rep1_sites.bed"],   assays(se.unsorted)$circ[, "FrontalCortex_rep1_sites.bed"])
   # sorted vs. unsorted, resTable()
   expect_equal(resTable(se.sorted)$FrontalCortex_rep1_sites.bed_circ, resTable(se.unsorted)$FrontalCortex_rep1_sites.bed_circ)
 })


### PR DESCRIPTION
This PR adds `lintr` to the test suite to ensure that style guidelines met so far remain respected.

The `.lintr` file lists the linters skipped (for now) as those would result in a failed test.

Eventually, all of the should be enabled unless we explicitely decide to break one of the recommendations (see #27).