### PR TITLE
excluded test-loadAnnot.R from coverage analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ sudo: required
 bioc_required: true
 
 after_success:
-- Rscript -e 'covr::codecov()'
+- Rscript -e 'covr::codecov(line_exclusions = "inst/scripts/test_load_data.R")'


### PR DESCRIPTION
I have no clue why @lintr-bot keeps spamming about the disabled `camel_case_linter`.
Also `covr` doesn't seem to get triggerd by command line merges, so you might want to open a pull request before merging to `master`.