### PR TITLE
Add testing on previous release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ r_github_packages:
 
 # See https://docs.travis-ci.com/user/languages/r/#R-Versions
 r:
-#  - oldrel
+  - oldrel
   - release
   - devel
 


### PR DESCRIPTION
Eventually, we want to support not only the latest version of R.

Currently, the build fail due to [missing `SummerizedExperiment`](https://travis-ci.org/BIMSBbioinfo/ciRcus/jobs/221624980#L4231).

As for the Window testing branch, I will keep re-basing this onto dev to re-trigger Travis until this works.

There is no need for us to actively invest time in getting this to work, but once it does, we should try to keep it working. :wink: