### PR TITLE
[wrong base]: cleanup leftover code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ciRcus
 Type: Package
 Title: Annotation, analysis and visualization of circRNA data
-Version: 0.1.5
+Version: 0.1.6
 Author: Petar Glazar [aut, cre], Vedran Franke [aut, cre], Marcel Schilling [aut, cre]
 Maintainer: Petar Glazar <petar.glazar@gmail.com>, Vedran Franke
     <vedran.franke@gmail.com>, Marcel Schilling <marcel.schilling@mdc-berlin.de>

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -15,7 +15,7 @@ gtf2sqlite <-
 
   ah <- AnnotationHub()
   gtf.gr <- ah[[getOption("assembly2annhub")[[assembly]]]]
-  gtf.gr <- keepStandardChromosomes(gtf.gr)
+  gtf.gr <- keepStandardChromosomes(gtf.gr, pruning.mode = "coarse")
   seqlevels(gtf.gr) <- paste("chr", seqlevels(gtf.gr), sep = "")
   seqlevels(gtf.gr)[which(seqlevels(gtf.gr) == "chrMT")] <- "chrM"
   txdb <- makeTxDbFromGRanges(gtf.gr, drop.stop.codons = FALSE,

--- a/R/circus.R
+++ b/R/circus.R
@@ -79,14 +79,7 @@ NULL
                             "dm6"      = "current",
                             "rn5"      = "79",
                             "WBcel235" = "81"
-                            ),
-
-    assembly2organism = list("hg19"     = "hsa",
-                             "hg38"     = "hsa",
-                             "mm10"     = "mmu",
-                             "dm6"      = "dme",
-                             "WBcel235" = "cel"
-                             )
+                            )
 
   )
   toset <- !(names(op.circus) %in% names(op))


### PR DESCRIPTION
Remove `assembly2organism` which was defined in `circus.R` but not used anywhere
else. When it was introduced in 82b261e491e18ad4750da53f64296c8ec88036bb it used be used in `annotate.R`, but that is no longer the case.