### PR TITLE
Cleanup leftover code

### DIFF
--- a/R/circus.R
+++ b/R/circus.R
@@ -85,14 +85,7 @@ NULL
                             "rn5"      = "79",
                             "rn6"      = "91",
                             "WBcel235" = "81"
-                            ),
-
-    assembly2organism = list("hg19"     = "hsa",
-                             "hg38"     = "hsa",
-                             "mm10"     = "mmu",
-                             "dm6"      = "dme",
-                             "WBcel235" = "cel"
-                             )
+                            )
 
   )
   toset <- !(names(op.circus) %in% names(op))


### PR DESCRIPTION
Remove assembly2organism which was defined in `circus.R` but not used anywhere else.

When it was introduced in 82b261e491e18ad4750da53f64296c8ec88036bb it used be used in `annotate.R`, but that is no longer the case.